### PR TITLE
Update Replicate_Landslide_model_for_fire.ipynb

### DIFF
--- a/landslide_model_for_fire/Replicate_Landslide_model_for_fire.ipynb
+++ b/landslide_model_for_fire/Replicate_Landslide_model_for_fire.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "The shallow landslide model you will is based on a spatially distributed Monte Carlo solution of the infinite slope stability model. Detailes of the model and the study site are described in Strauch et al. (2018).\n",
     "\n",
-    "Strauch R., Istanbulluoglu E., Nudurupati S.S., Bandaragoda C., Gasparini N.M., and G.E. Tucker (2018). A hydro-climatological approach to predicting regional landslide probability using Landlab. Earth Surf. Dynam., 6, 1–26, 2018. \n",
+    "Strauch R., Istanbulluoglu E., Nudurupati S.S., Bandaragoda C., Gasparini N.M., and G.E. Tucker (2018). A hydro-climatological approach to predicting regional landslide probability using Landlab. Earth Surf. Dynam., 6, 1–26. \n",
     "https://www.earth-surf-dynam.net/6/1/2018/\n",
     "\n",
     " <br /> <img src=\"https://www.washington.edu/brand/files/2014/09/W-Logo_Purple_Hex.png\" style=\"float:left;width:120px;padding:10px\">   \n",
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Relative wetness is the ratio of depth of water subsurface flow above an impervious bedrock to the depth of soil. "
+    "Relative wetness is the ratio of depth of water subsurface flow above an impervious layer to the depth of soil. "
    ]
   },
   {
@@ -112,7 +112,7 @@
    "source": [
     "R: recharge rate to water table (m/d)\n",
     "T: soil transmissivity (m^2/d)\n",
-    "a: specific catchment area."
+    "a: specific catchment area (m)."
    ]
   },
   {
@@ -1268,7 +1268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The landslide component employes the infinite slope model to calculate factor-of-safety index values using a Monte Carlo simulation, which randomly selects input values from parameter distributions. You can specify the number of Monte Carlo samples, but the default is 250. The larger the Monte Carlos sample size, the longer the program runs, but the more precise the probability of failure results become.Strauch et al. (2018) sapmple 3,000 times for each parameter in each model grid."
+    "The landslide component employes the infinite slope model to calculate factor-of-safety index values using a Monte Carlo simulation, which randomly selects input values from parameter distributions. You can specify the number of Monte Carlo samples, but the default is 250. The larger the Monte Carlos sample size, the longer the program runs, but the more precise the probability of failure results become. Strauch et al. (2018) sampled 3,000 times for each parameter in each model grid."
    ]
   },
   {
@@ -1472,7 +1472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make a 'grid_fire' version of 'grid' for which we will give post-fire cohesion parameter values 30% of the original cohesion. This is a crude estimation of the lowest root cohesion after tree removal based on a combined decay and regroth model (e.g., Sidle, 1992).\n",
+    "Make a 'grid_fire' version of 'grid' for which we will give post-fire cohesion parameter values 30% of the original cohesion. This is a crude estimation of the lowest root cohesion after tree removal based on a combined decay and regrowth model (e.g., Sidle, 1992).\n",
     "\n",
     "Sidle, R. C. (1992), A theoretical model of the effects of timber harvesting\n",
     "on slope stability, Water Resour. Res., 28(7), 1897–1910.\n",
@@ -1643,7 +1643,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Save the arrays as variables by 'attaching the fields to the grid' and view the outputs. **component already does this**\n",
     "\n",
     "This simulation generates a probability value for each core node. "
    ]


### PR DESCRIPTION
Fixed a few typos and removed reference to saving arrays as variables.