### PR TITLE
overland flow tut: code style, legends in figures, some text clarified

### DIFF
--- a/explore_flow_routing/explore_routing_tutorial.ipynb
+++ b/explore_flow_routing/explore_routing_tutorial.ipynb
@@ -13,41 +13,62 @@
    "source": [
     "# Exploring overland flow routing with Landlab\n",
     "\n",
-    "To swiftly develop experiments using community resources is an extraordinary emerging opportunity to accelerate the rate of scientific advancement.The ability to test hypotheses about hydrology, geomorphology and atmospheric processes is invaluable to research in the Earth and planetary sciences; using cyber-infrastructure that allows formal publication and sharing of data and model online is an emerging approach in many research communities. \n",
-    "\n",
-    "**Science activities**\n",
-    "* Introduce Shallow Water Equation, Test Area, Model Steps, and Curriculum Questions. <br />\n",
+    "## Objectives\n",
+    "* Introduce the Shallow Water Equation, Test Area, Model Steps, and Curriculum Questions.\n",
     "* Use Landlab to set up a comparative model experiment.\n",
-    "* Run a Landlab model.<br />\n",
-    "* Explore flow sensitivity.\n",
-    "* Save results to a new HydroShare resource.  <br />\n",
-    "<br />\n",
+    "* Run a Landlab model.\n",
+    "* Explore flow sensitivity using model results.\n",
+    "* Save results to a new HydroShare resource."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## About this notebook\n",
     "\n",
-    "**Data Science and Cyberinfrastructure**\n",
+    "### Data Science and Cyberinfrastructure\n",
     "\n",
-    "This notebook is a computational narrative using the [Landlab](http://landlab.github.io) Python-based modeling environment that allows scientists and students to build numerical landscape models.\n",
-    "This work also utilized the following open source research software libraries: numpy, matplotlib, pandas, and hydroshare. The software environment is provided by the [CUAHSI JupyterHub server](https://jupyter.cuahsi.org). \n",
+    "This notebook is a computational narrative using the [Landlab](http://landlab.github.io) Python-based modeling toolkit that allows scientists and students to build numerical landscape models. This notebook also utilizes the following open source research software libraries: [NumPy](http://www.numpy.org), [Matplotlib](https://matplotlib.org), [Pandas](https://pandas.pydata.org), and [HydroShare](https://www.hydroshare.org). The software environment is provided by the [CUAHSI JupyterHub server](https://jupyter.cuahsi.org). \n",
+    "<hr>\n",
     "\n",
-    "_To run this notebook:_\n",
+    "**[Click here for additional Landlab tutorials](https://github.com/landlab/landlab/wiki/Tutorials)**\n",
+    "<hr>\n",
     "\n",
-    "Click in each shaded code block below and use \"shift + enter\" keys. Alternatively, you can run groups of cells by clicking \"Cell\" on the menu above and selecting among the various run options. This is also where you can clear outputs from previous runs.\n",
+    "### How to use this notebook\n",
     "\n",
-    "Every time you run this notebook the model outputs you generated are saved in your personal user space in the virtual computer through Hydroshare. These outputs are available for you to plot and explore the models using the plotting functions at the end of this tutorial. \n",
+    "#### Navigation\n",
     "\n",
-    "Your final results can be saved to Hydroshare, see section 5.0 below.\n",
-    "Unwanted model output can be deleted at anytime from your space. For this run the last code block of this tutorial. \n",
+    "This notebook is made of text cells, including the cell you are reading now, and code cells. The order in which you run the cells matters. The notebook cells are generally designed to be run top to bottom.\n",
     "\n",
-    "If an error occurs, click on *Kernal* and *Restart and Clear Outputs* in the menu above.\n",
-    "<hr> <small> For more instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a></small><br>\n",
+    "Code cells have the following characters to their left:\n",
+    "* `In [ ]:` is a cell yet to be run.\n",
+    "* `In [*]:` is a cell that is running.\n",
+    "* `In [n]:` where `n` is an integer, is a cell that has run. The number indicates the sequence the cell was run, i.e. the first cell run is `n`=1.\n",
     "\n",
-    "**Acknowledgements**\n",
+    "The code in a notebook is ran one cell at a time. Place your cursor in a code cell, hold down `shift` and then also press `enter`. You can even experiment with typing your own code into a cell and running that.\n",
     "\n",
-    "This notebook was developed from code written by Jordan Adams as part of her PhD disseration at Tulane University and Amanda Manaster as a tutorial for a Landlab workshop at the Geophysical Society of America Annual Meeting, Seattle, WA, 2018. Nathan Lyons provided code and technical support on animations.   \n",
+    "Alternatively, you can run groups of cells by clicking `Cell` on the menu above and then selecting among the various run options. This is also where you can clear outputs from previous runs.\n",
     "\n",
-    "Use or citation of this notebook should also reference: Adams, J. M., Gasparini, N. M., Hobley, D. E. J., Tucker, G. E., Hutton, E. W. H., Nudurupati, S. S., and Istanbulluoglu, E.: The Landlab v1.0 OverlandFlow component: a Python tool for computing shallow-water flow across watersheds, Geosci. Model Dev., 10, 1645-1663, https://doi.org/10.5194/gmd-10-1645-2017, 2017.\n",
+    "You can also `shift` + `enter` in a text cell to advance your place in the notebook.\n",
     "\n",
+    "See [this page](https://github.com/landlab/tutorials/blob/master/README.md) for more instructions on how to use an interactive Jupyter notebook.\n",
     "\n",
-    "<small>For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a></small>"
+    "#### Output\n",
+    "\n",
+    "Every time you run this notebook the model outputs you generate are saved in your personal user space in the virtual computer through Hydroshare. These outputs are available for you to plot and explore using the plotting functions. We will plot model output at the end of this tutorial. \n",
+    "\n",
+    "Your final results can be saved to Hydroshare as a resource (see section 9.0 below). Unwanted model output can be deleted at anytime from your space, including by running the final code block of this tutorial. \n",
+    "\n",
+    "If an error occurs, click on the upper menu bar item, `Kernal` and then select `Restart and Clear Outputs` in the drop down menu.\n",
+    "\n",
+    "### Acknowledgements\n",
+    "\n",
+    "This notebook was developed from code written by Jordan Adams as part of her Ph.D. disseration at Tulane University and Amanda Manaster as a tutorial for a Landlab workshop at the Geophysical Society of America Annual Meeting, Seattle, WA, 2018. Nathan Lyons provided code and technical support on animations.   \n",
+    "\n",
+    "Use or citation of this notebook should also reference:\n",
+    "\n",
+    "Adams, J. M., Gasparini, N. M., Hobley, D. E. J., Tucker, G. E., Hutton, E. W. H., Nudurupati, S. S., and Istanbulluoglu, E.: The Landlab v1.0 OverlandFlow component: a Python tool for computing shallow-water flow across watersheds, Geosci. Model Dev., 10, 1645-1663, https://doi.org/10.5194/gmd-10-1645-2017, 2017."
    ]
   },
   {
@@ -75,13 +96,13 @@
     "&nbsp;&nbsp;&nbsp;&nbsp;$R = hydraulic \\space radius \\left[L\\right]$  \n",
     "&nbsp;&nbsp;&nbsp;&nbsp;$A_{xs} = cross-sectional \\space area \\left[L^2\\right]$ \n",
     "\n",
-    "From left to right terms in Equation (1) represent local acceleration, convective acceleration, gradients of fluid pressure and bed elevation, and friction. Because this equation is difficult (i.e., almost impossible) to solve explicitly, approximations are commonly used. The simplest approximation, the Kinematic Wave model, only retains the friction term, making it the simplest approximation one can use. In Landlab KinwaveImplicitOverlandFlow component provides a 2-D locally implicit kinematic wave solution in which energy slope is assumed to be equal to the bed slope. \n",
+    "From left to right, the terms in Equation (1) represent local acceleration, convective acceleration, gradients of fluid pressure and bed elevation, and friction. Because this equation is difficult (i.e., almost impossible) to solve explicitly, approximations are commonly used. The simplest approximation, the Kinematic Wave model, only retains the friction term, making it the simplest approximation one can use. The Landlab `KinwaveImplicitOverlandFlow` component provides a 2-D locally implicit kinematic wave solution in which energy slope is assumed to be equal to the bed slope. \n",
     "\n",
-    "The diffusive model developed from Equation (1) neglects the first two terms. The Landlab OverlandFlow component (Adams et al. 2017) adapts a 2D hydrodynamic algorithm similar to the diffusive approximation with negligible advection term (de Almeida et al., 2012) used in LISFLOOD-FP. The flow geometry is assumed to be rectangular and of constant flow width. The approximation used in OverlandFlow is more accurate but also more computationally expensive than the approximation used in KinwaveImplicitOverlandFlow.  \n",
+    "The diffusive model developed from Equation (1) neglects the first two terms. The Landlab `OverlandFlow` component (Adams et al. 2017) adapts a 2D hydrodynamic algorithm similar to the diffusive approximation with negligible advection term (de Almeida et al., 2012) used in LISFLOOD-FP. The flow geometry is assumed to be rectangular and of constant flow width. The approximation used in `OverlandFlow` is more accurate but also more computationally expensive than the approximation used in `KinwaveImplicitOverlandFlow`.  \n",
     "\n",
-    "<small>Click here for the OverlandFlow Component Users Manual \"https://github.com/landlab/landlab/wiki/OverlandFlow-Component-Users-Manual</a></small><br>\n",
+    "<small>Click here for the OverlandFlow Component Users Manual: https://github.com/landlab/landlab/wiki/OverlandFlow-Component-Users-Manual</a></small><br>\n",
     "\n",
-    "This tutorial illustrates the use of both the KinwaveImplicitOverlandFlow and the OverlandFlow components to map overland flow depth across two modeling domains and plot flow hydrograph at the outlet and several internal nodes. We will use two domains:\n",
+    "This tutorial illustrates the use of both the `KinwaveImplicitOverlandFlow` and the `OverlandFlow` components to map overland flow depth across two modeling domains and plot a flow hydrograph at the outlet and several internal nodes. We will use two domains:\n",
     "\n",
     "* Spring Creek watershed, CO, USA \n",
     "* A synthetic landscape modeled with Landlab   \n",
@@ -93,30 +114,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "** Terms:** runoff intensity, runoff duration, peak discharge, hydrograph time to peak, rising limb, falling limb. "
+    "**Terms:** runoff intensity, runoff duration, peak discharge, hydrograph time to peak, rising limb, falling limb. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.2. Landscapes \n",
+    "### 1.2. Model Domains \n",
     "\n",
-    "The natural catchment used in this tutorial is the Spring Creek watershed, a steep 27 $km^2$ watershed located in central Colorado. The DEM we will use has a resolution of 30 meters (Adams et al. 2017). To clearly contrast landscape shape, this notebook uses a modeled \"synthetic\" landscapes produced using a landscape evolution model developed in Landlab by coupling hillslope diffusion transopt and stream-power erosion rules. The landscape evolution model was run on 36 km$^2$ area represented by regular grids of 30 m size. \n",
+    "The natural catchment used in this tutorial and studied in Adams et al. (2017) is the Spring Creek watershed, a steep 27 km$^2$ watershed located in central Colorado. The digital elevation model (DEM) we will use has a resolution of 30 meters. To clearly contrast landscape shape, this notebook uses a modeled \"synthetic\" landscape produced using a model developed in Landlab by coupling hillslope diffusion and stream-power erosion rules. The landscape evolution model was run on a 36 km$^2$ area represented by regular grids with a node spacing of 30 m. \n",
     "\n",
-    "These watershed domains are available at the Landlab Github site and as Hydroshare resource, and will be imported as part of this exercise.\n",
+    "These watershed domains are available at the Landlab Github site and as Hydroshare resources, and will be imported as part of this exercise.\n",
     "\n",
     "### 1.3. Steps to Explore the Model\n",
     "\n",
-    "We will be running the two overland flow models for 6 hours with a storm at the beginning that lasts for 2 hours. We will visualize water depths across the watershed over the course of the simulation and plot hydrographs at the outlet and two internal nodes. In repeated model experiments you can investigate the influence of runoff intensity, runoff duration, and surface resistance on streamflow hydrographs. You can organize your results buy running the two models and saving results from each watershed domain before running the models for the other domain.  \n",
+    "We will run the two overland flow models for 6 hours. A storm begins at the onset of the simulation and lasts for 2 hours. We will visualize water depths across the watershed over the course of the simulation and plot hydrographs at the outlet and two internal nodes.\n",
     "\n",
-    "Start at the top by reading each block of text and sequentially running each code block (put your curser in a code block and type shift + enter OR got to the _Cell_ pulldown menu at the top and choose _Run Cells_). \n",
+    "In repeated model experiments you can investigate the influence of runoff intensity, runoff duration, and surface resistance on streamflow hydrographs. You can organize your approach by running the two models and saving results from each watershed domain before running the models for the other domain.  \n",
     "\n",
-    "Remember that you can always go to the _Kernel_ pulldown menu at the top and choose _Restart & Clear Output_ or _Restart & Run All_ if you change things and want to start afresh. \n",
+    "Revisit the 'How to use this notebook' section at the top of the page as needed.\n",
     "\n",
     "### 1.4. Questions to consider before running this notebook\n",
     "\n",
-    "Hydrograph characterics you will focus are: time to peak, peak discharge, and hydrograph shape. \n",
+    "We will focus on the hydrograph characteristics, time to peak, peak discharge, and hydrograph shape. \n",
     "\n",
     "1. How do watershed shape and drainage area affect hydrograph characteristics? \n",
     "2. How does runoff intensity impact the time to peak and peak discharge across the channel network? \n",
@@ -128,19 +149,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2.0 Data Science & Cyberinfrastructure Methods\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.1 Import Landlab components"
+    "## 2.0 Data Science & Cyberinfrastructure Methods\n",
+    "\n",
+    "### 2.1 Import Landlab components and additional modules"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,22 +173,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2 Import functions for importing data and plotting tools"
+    "### 2.2 Import standard,  plotting, and numeric modules"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import copy  \n",
+    "import copy\n",
+    "import os\n",
+    "\n",
+    "from IPython.display import HTML\n",
     "from matplotlib import pyplot as plt\n",
-    "import matplotlib.image as mgimg\n",
     "import matplotlib.animation as animation\n",
-    "%matplotlib inline "
+    "import matplotlib.image as mgimg\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Set the environment to place plots in Jupyter cells.\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -180,49 +202,20 @@
    "metadata": {},
    "source": [
     "### 2.3 Import HydroShare tools\n",
-    "Using the `hs_utils` library, the results of the Geoprocessing steps below will be saved back into HydroShare.   These are needed to import data from hydroshare and create new hydroshare resources with your results"
+    "\n",
+    "The results of the Geoprocessing steps below will be saved in the HydroShare environment using the `hydroshare` library. These are needed to import data from HydroShare and create new HydroShare resources with your results."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Adding the following system variables:\n",
-      "   HS_USR_NAME = ChristinaBandaragoda\n",
-      "   HS_RES_ID = 70b977e22af544f8a7e5a803935c329c\n",
-      "   HS_RES_TYPE = genericresource\n",
-      "   JUPYTER_HUB_IP = jupyter.cuahsi.org\n",
-      "\n",
-      "These can be accessed using the following command: \n",
-      "   os.environ[key]\n",
-      "\n",
-      "   (e.g.)\n",
-      "   os.environ[\"HS_USR_NAME\"]  => ChristinaBandaragoda\n",
-      "Successfully established a connection with HydroShare\n",
-      "This is the list of folders in your directory for this HydroShare resource.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'/home/jovyan/work/notebooks/data/70b977e22af544f8a7e5a803935c329c/70b977e22af544f8a7e5a803935c329c/data/contents'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
     "from utilities import hydroshare\n",
-    "hs=hydroshare.hydroshare()\n",
-    "print('This is the list of folders in your directory for this HydroShare resource.')\n",
+    "\n",
+    "hs = hydroshare.hydroshare()\n",
+    "print('This is the list of folders in your directory of this HydroShare resource.')\n",
     "os.getcwd()"
    ]
   },
@@ -230,49 +223,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.4. Import Digital Elevation Models (DEMs) from a HydroShare resource with two methods \n",
+    "### 2.4. Import DEMs from a HydroShare resource with two methods \n",
     "\n",
-    "Now we import the elevation data for the study watersheds. Here we show two ways of importing watershed elevation data from a URL: 1) raw file on Github; 2) a public Hydroshare resource. Both of these methods require some familiarity with these platform."
+    "Now we import the elevation data for the study watersheds. Here we show two ways of importing watershed elevation data from a URL:\n",
+    "\n",
+    "1. from a raw file on Github\n",
+    "2. from a public Hydroshare resource\n",
+    "\n",
+    "Both of these methods require some familiarity with these platforms."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--2018-09-15 00:15:20--  https://raw.githubusercontent.com/landlab/pub_adams_etal_gmd/master/ASCII%20files/Square_TestBasin.asc\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.32.133\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.32.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 1000861 (977K) [text/plain]\n",
-      "Saving to: ‘Square_TestBasin.asc.2’\n",
-      "\n",
-      "Square_TestBasin.as 100%[===================>] 977.40K  6.29MB/s    in 0.2s    \n",
-      "\n",
-      "2018-09-15 00:15:20 (6.29 MB/s) - ‘Square_TestBasin.asc.2’ saved [1000861/1000861]\n",
-      "\n",
-      "--2018-09-15 00:15:20--  https://raw.githubusercontent.com/landlab/pub_adams_etal_gmd/master/ASCII%20files/SpringCreek_DEM.asc\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.32.133\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.32.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 1808960 (1.7M) [text/plain]\n",
-      "Saving to: ‘SpringCreek_DEM.asc.2’\n",
-      "\n",
-      "SpringCreek_DEM.asc 100%[===================>]   1.72M  7.67MB/s    in 0.2s    \n",
-      "\n",
-      "2018-09-15 00:15:21 (7.67 MB/s) - ‘SpringCreek_DEM.asc.2’ saved [1808960/1808960]\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#Get from raw URL on Github \n",
+    "# Get data from a raw URL on Github (the DEM is the model data).\n",
     "!wget https://raw.githubusercontent.com/landlab/pub_adams_etal_gmd/master/ASCII%20files/Square_TestBasin.asc\n",
-    "#Spring Creek Basin: Get from public URL on HydroShare\n",
+    "    \n",
+    "# Get data from a public URL on HydroShare (the data is a DEM of the natural domain, Spring Creek Basin).\n",
     "!wget https://raw.githubusercontent.com/landlab/pub_adams_etal_gmd/master/ASCII%20files/SpringCreek_DEM.asc"
    ]
   },
@@ -280,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note** if you run the cell above multiple times you will generate multiple ascii files of watershed DEMs. To avoid this by deleting previous versions, copy and paste the code below into a cell or remove the comments in the cell below and run: \n",
+    "**Note**: If you run the cell above multiple times you will generate multiple ascii files of watershed DEMs. To delete previous versions, copy and paste the code below into a cell, or in the cell below remove the comment symbol, `#` and then run the cell: \n",
     "\n",
     "```\n",
     "!rm SpringCreek_DEM*\n",
@@ -290,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,16 +279,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Square Basin\n",
+    "# Square Basin\n",
     "watershed_dem_sq = 'Square_TestBasin.asc'\n",
     "(rmg_sq, z_sq) = read_esri_ascii(watershed_dem_sq, name='topographic__elevation')\n",
     "rmg_sq.set_watershed_boundary_condition(z_sq)\n",
     "\n",
-    "#Spring Creek Basin\n",
+    "# Spring Creek Basin\n",
     "watershed_dem_sc = 'SpringCreek_DEM.asc'\n",
     "(rmg_sc, z_sc) = read_esri_ascii(watershed_dem_sc, name='topographic__elevation')\n",
     "rmg_sc.set_watershed_boundary_condition(z_sc)"
@@ -330,20 +300,21 @@
    "source": [
     "### 3.2. Use Landlab to calculate flow accumulation and drainage area  \n",
     "\n",
-    "Drainage areas derived in this step will be used in selecting internal points for plotting hydrograhs "
+    "Drainage areas derived in this step will be used in selecting internal points for plotting hydrographs. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Square Basin\n",
+    "# Square Basin\n",
     "fa_sq = FlowAccumulator(rmg_sq)\n",
     "fa_sq.run_one_step()\n",
     "(da_sq, q_sq) = fa_sq.accumulate_flow()\n",
-    "#Spring Creek\n",
+    "\n",
+    "# Spring Creek\n",
     "fa_sc = FlowAccumulator(rmg_sc)\n",
     "fa_sc.run_one_step()\n",
     "(da_sc, q_sc) = fa_sc.accumulate_flow()"
@@ -353,233 +324,157 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3. List and select nodes with drainage area greater than a threshold  \n",
+    "### 3.3. List and select the nodes with a drainage area greater than a threshold  \n",
     "\n",
-    "Below we show how you can identify internal nodes in the two domains for plotting streamflow hydrographs. We selected nodes such that the watershed areas above mid and upstream nodes of the two watersheds are close to each other. This gives us the opportunity to compare hydrographs in relation to watershed shape and watershed relief above each node, given the similar watershed area values."
+    "Below we show how you can identify internal nodes in the two domains for plotting streamflow hydrographs. We selected nodes such that the watershed areas above mid and upstream nodes of the two watersheds are close to each other. This gives us the opportunity to compare hydrographs in relation to watershed shape and watershed relief above each node, given the similar watershed area values.\n",
+    "\n",
+    "The midstream and upstream node drainage area thresholds can be identified by drainage area ranges in km$^2$. The range used to identify a midstream location should be larger than the range used to identify an upstream location. These internal nodes can be identified by trial using different drainage area values, and plotting the locations selected. After we select the drainage area ranges we will print the node IDs, drainge areas, and elevations of the locations we select and map the locations on the elevation map of the watershed. To continue your project with the Square domain you can skip the steps in 2.5.2 that pertains to Spring Creek and move to 2.6. After modeling flows in the Square domain you will need to come back to 2.5.2. and identify the nodes you would like to include for hydrograph analysis in Spring Creek. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The midstream and upstream node drainage area thresholds can be identified by drainge area ranges in km2. The range used to identify a midstream location should be larger than the range used to identify an upstream location. These internal nodes can be identified by trial using different drainage area values, and plotting the locations selected. After we select the drainage area ranges we will print the node IDs, drainge areas, and elevations of the locations we select and map the locations on the elevation map of the watershed. To continue your project with the Square domain you can skip the steps in 2.5.2 that pertains to Spring Creek and move to 2.6. After modeling flows in the Square domain you will need to come back to 2.5.2. and identify the nodes you would like to include for hydrograph analysis in Spring Creek. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**3.3.1 Square Basin: a) set thresholds and b) select output nodes**\n",
+    "#### 3.3.1 Square Basin: a) set thresholds and b) select output nodes\n",
     "\n",
-    "We will identify the nodes for outlet, midstream, and upstream locations for plotting hydrographs using drainge area thresholds for the latter two. Code is written to set the outlet at the node with the largest drainage area. Below we will first identify the outlet node ID, its elevation and drainage area.  "
+    "We will identify the nodes for the outlet, midstream, and upstream locations for plotting hydrographs using drainage area thresholds for the latter two. Code is written to set the outlet at the node with the largest drainage area. Below we will first identify the outlet node ID, its elevation and drainage area.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outlet Node = 100; Drainage Area= 35.28 km2; Elev = 0.0 m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "outlet_node_to_sample_sq = np.argmax(rmg_sq.at_node['drainage_area'])\n",
-    "print('Outlet Node = ' + str(outlet_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[outlet_node_to_sample_sq]/1000000) + ' km2; Elev = '+ str(round(z_sq[outlet_node_to_sample_sq],1)) + ' m')"
+    "\n",
+    "print('Outlet Node = ' + str(outlet_node_to_sample_sq) + '; Drainage Area = ' + str(da_sq[outlet_node_to_sample_sq] / 1000000) + ' km^2; Elev = '+ str(round(z_sq[outlet_node_to_sample_sq],1)) + ' m')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outlet Node = 100; Drainage Area= 35.28 km2; Elev = 0.0 m\n",
-      "Midstream Node = 10502; Drainage Area= 18.3537 km2; Elev = 7.3 m\n",
-      "Upstream Node = 31113; Drainage Area= 3.528 km2; Elev = 38.4 m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "## These values can be change to set drainage area thresholds in km2\n",
-    "midstream_da_upperbound=20\n",
-    "midstream_da_lowerbound=12\n",
-    "upstream_da_upperbound=4\n",
-    "upstream_da_lowerbound=3\n",
+    "# These values can be change to set drainage area thresholds in km^2\n",
+    "midstream_da_upperbound = 20\n",
+    "midstream_da_lowerbound = 12\n",
+    "upstream_da_upperbound = 4\n",
+    "upstream_da_lowerbound = 3\n",
     "\n",
-    "midstream_node_to_sample_sq = np.where(np.logical_and(rmg_sq.at_node['drainage_area']>midstream_da_lowerbound*1000000, rmg_sq.at_node['drainage_area']<midstream_da_upperbound*1000000))[0][-1]\n",
-    "upstream_node_to_sample_sq = np.where(np.logical_and(rmg_sq.at_node['drainage_area']>upstream_da_lowerbound*1000000, rmg_sq.at_node['drainage_area']<upstream_da_upperbound*1000000))[0][-1]\n",
+    "midstream_node_to_sample_sq = np.where(np.logical_and(rmg_sq.at_node['drainage_area'] > midstream_da_lowerbound * 1000000, rmg_sq.at_node['drainage_area'] < midstream_da_upperbound * 1000000))[0][-1]\n",
+    "upstream_node_to_sample_sq = np.where(np.logical_and(rmg_sq.at_node['drainage_area'] > upstream_da_lowerbound * 1000000, rmg_sq.at_node['drainage_area'] < upstream_da_upperbound * 1000000))[0][-1]\n",
     "\n",
-    "print('Outlet Node = ' + str(outlet_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[outlet_node_to_sample_sq]/1000000) + ' km2; Elev = '+ str(round(z_sq[outlet_node_to_sample_sq],1)) + ' m')\n",
-    "print('Midstream Node = ' + str(midstream_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[midstream_node_to_sample_sq]/1000000) + ' km2; Elev = '+ str(round(z_sq[midstream_node_to_sample_sq],1)) + ' m')\n",
-    "print('Upstream Node = ' + str(upstream_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[upstream_node_to_sample_sq]/1000000) + ' km2; Elev = '+ str(round(z_sq[upstream_node_to_sample_sq],1)) + ' m')"
+    "print('Outlet Node = ' + str(outlet_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[outlet_node_to_sample_sq] / 1000000) + ' km^2; Elev = '+ str(round(z_sq[outlet_node_to_sample_sq], 1)) + ' m')\n",
+    "print('Midstream Node = ' + str(midstream_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[midstream_node_to_sample_sq] / 1000000) + ' km^2; Elev = '+ str(round(z_sq[midstream_node_to_sample_sq], 1)) + ' m')\n",
+    "print('Upstream Node = ' + str(upstream_node_to_sample_sq) + '; Drainage Area= ' + str(da_sq[upstream_node_to_sample_sq] / 1000000) + ' km^2; Elev = '+ str(round(z_sq[upstream_node_to_sample_sq], 1)) + ' m')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7fde541dea50>]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMUAAACGCAYAAABt9E4yAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzsvXmwZFle3/c5d78393z51qrqrt6XGc0wgCBkMIFBFkhCwo7AAuTAyFYIW0aLbRRGOMIGG4MlhyxA4QgUYDCDhUAwdoQIAhsBtgILGTRbT093V/VU1/72l3vm3c89x3+c+7Kqa3p6XqHunp7u94vIeO9l3rw3893zO7/t+/39hNaaczmXc7kn1pf6A5zLubzb5FwpzuVcHpBzpTiXc3lAzpXiXM7lATlXinM5lwfkXCnO5VwekHOlOJdzeUDOleItFCHE1wsh/qUQYiaEGAshfl8I8ce/1J/rXB5OnC/1B3iviBCiDfwG8FeBXwU84N8E8nf4c9ha6+qdvOZ7Tc4txVsnTwNorX9Za11prVOt9T/TWr8ohLCFEH9PCDEUQtwQQny/EEILIRwAIcQtIcSfPD2REOJHhBD/6L6/f00IcVhboN8TQnzgvtd+QQjx00KI3xRCxMC/JYTw6+vdEUIcCSH+oRAifAf/F1/Wcq4Ub518DqiEEB8VQvxpIUTvvtf+CvBtwEeArwa+4yHP/X8CTwEbwKeAX3rg9b8I/BjQAv4F8HcxSvoVwJPABeC/echrvm/lXCneItFaz4GvBzTws8CJEOLXhRCbwF8AflJrfVdrPQb+h4c8989rrRda6xz4EeDDQojOfYf8U63172utFcZd+yvAf661HmutF8CPA9/1r/sd3y9yHlO8haK1vgL8JQAhxLPAPwJ+EtgB7t536O2znlMIYWOswL8HrAOqfmkAzOrf7z/3OhABnxRCrE4D2Gf/Ju9vObcUb5Nora8CvwB8EDgALt338iMPHB5jFvKpbN33+18Evh34k0AHuFw/L+475n6o8xBIgQ9orbv1o6O1bv7Rvsn7T86V4i0SIcSzQogfEEJcrP++BHw38AeYbNTfEEJcrGONv/3A218AvksI4QohHow5WhiXaIRRnB9/s89Ru1A/C/yEEGKj/iwXhBDf8q/9Jd8ncq4Ub50sgK8F/rDOAv0B8BLwA5hF+lvAZzCB8v/xwHv/a+AJYAL8t8A/vu+1X8S4W3vAK/V5v5j8IPAa8AdCiDnwO8Azf6Rv9T4UcU4yeudFCHEZuAm4Wmv5pf005/KgnFuKczmXB+RtVQohRFcI8TEhxFUhxBUhxJ8QQvSFEL8thLhW/+zVxwohxD8QQrwmhHhRCPGV953ne+vjrwkhvvft/Mznci5vt6X4KeD/0lo/C3wYuIIJMn9Xa/0U8LvcCzr/NKZA9RTwfcBPAwgh+sAPY/z1rwF++IHC2JedaK1vaa3Fuev07pS3TSlqLNA3AD8HoLUutNZTTHrxo/VhHwX+nfr3bwd+URv5A6ArhNgGvgX47boQNQF+G/jWt+tzn8u5vJ3Fu8eBE+B/FUJ8GPgk8DeBTa31AYDW+uA0bYiBItxfhNqtn/tCz79OhBDfh7EwNBqNr3r22Wff2m9zLn8k+eQnPznUWq9/ode/9Vu/VQ+Hwwff81ta6y/Zxvd2KoUDfCXw17XWfyiE+Ck+Pz9/v4g3eE6/yfOvf0LrnwF+BuCrv/qr9e/93scoihFKZThOi3h+i6CxRZ4d4bhNktGQaG2A6/bQWqJUiVIpYfgYnme8szTdJV7coNl+CiEcLCtACIs8P0DKGbJIcLwmluWTp0PksiDod0hOJvjdkORgjr8W0exdJkv3KBY5aE2VS4QlcJs+YXuH5fEdWpuXSWa7AFSZxA4cqqIi2Z8T7bQpZhnZMMYJXCzXwml6+L2IKiupMmmO3Z3hNDyKWUa42cQOXYSAeHdOlUm8XoDb9PG6AdF6j/hojJYK27fJpxnNiwY5YvsByfGU5tY6VZXiun20LsxNEh7p9AAn8nDcDr6/hef1SJLbRNGjCOHiuvcQKEKIN63eD4dDPv7xf/W65yzLHrzZe95ueTuVYhfY1Vr/Yf33xzBKcSSE2K6txDZwfN/x91d9LwL79fPf+MDz//zNLqxUxnz2WYQQpMdLnMgln6QUjYxykRNtVcR3ZziBS5qP0ErjhC5VJnG3elRVjBA2RXFMMcuYl1dxowitSoRlkY1jymWBTErCzYzm+gV0pYn3ZgjHYnlnCsDyjkFhqPw66UlMOc/QWlOlZtG7TR/rGZv0eInWN5FJST5OqDKJv2YK3MtbU5zQpZhlJHfnuC2PclHgtn2C9YhyUaAKiR25LF4d4a2FpLsL8mGC0/AQFpTzAjt0oBcAIJcFmT1jeWuC1wkoF5CPEizXIEHsICPZm2M5Fvk4xW0vcQKzVJyGR7y/oPPkWv2/LsjzIcnsLrYdorWkqgZUVU6j8dgZlonmHnLl3SFvm1JorQ+FEHeFEM9orV8FvhlTfHoF+F7g79Q//2n9ll8H/poQ4lcwQfWsVpzfAn78vuD6TwE/9ObXrsjH5ibn45RykSOTEmFblPMc2faRy4LkcIEqKnSl8XoBQgiKwphy246QRYyMC8pFTmYneG2f1sZlnI2ceXGXfJxgew7x6ACURiYlyf6ccmauJ5cFxSwjWG8SrEcIW1ClJenugvYzAyzfNudfFuhKk48TykVBVX9WADnPKWOjgHKeIwToShHttHAil/RgQXYQ429EKKkoZzlxlhPYLZJbM7DA64cUoxTLd6hSiVYaYQvKWYawjCEuphlu2wegSm3KRU56tKRc5sikWClplUuqrKRc5qhwQjYfEnUvUMYFc/UqQbuPEC5KnZ1G8m6jf7zdgMC/DvySEMIDbgD/ISa4/1UhxF8G7mCAbgC/CfwZTCU2qY9Faz0WQvwo8PH6uP+uRpp+QdFagxBkJzEyK1GzClVWWJ5tdvhUIpOS+M4U4dhYroXXCyhmGTI9xA4cvE6A3+zi9woWtyaEWy0agwvE4zuUSYlWGlVUqKIi3p8jk4IqLYlnGVVWoXJJlUl0pSkXGdkoRcYFWilUUVFMUzrPDJBpiYwLLMfC64U4TY/ZyyfIpVlUcmHOm+4vKGc5wrWwQ5dkf4G/FmKHLrpSVKkkSwqmJxMsIUiv7GMLgRACaxbjWBYyLnFaHm7bp9pqUs4LhGOT7i+MksxzsqMYYQuwRa2cgtKyKCYpWBaWLRCOxezaCKfh4bY8hLWPKirsbkiZz+u7cNYcjsYgU9498rYqhdb6BQx/4EH55jc4VgPf/wXO8/PAz5/1upbl4rUD/F6ITEqUrJh9bogqK6qkQFcKLRXBxQ7BIEKVFY3tPmXbWBetNK3e08TL1yhmGapUqLJa+dW2ZyNlvbjnGc1LHbTSVJkkn6TMrpyQncRUaUlVyHtuiW8jU4XKzc6opGJxa0KVlCwnGSqTqLyiyiXFNEdLRZGamMFfj8iPYlRe4UQuKpcry2f5DsUkw7Nt1lstwgsthG1RxSVaKoRjjut+ZBMncJFxwfLWFLkscNsewVYT2zefMdhsIFwLYVnmOmVlrIkQeF3jflWZRC4LtKyMZUsllnNPCYp0Rtj8vFzIG4rW7z9L8SURpUqyUUx56nrEpdn1hEAmkuXtKapSaFmt4onkeEo4aOAHW9h2g6I4oZznVJlEyQotFUoVtAbPMDu6Sj5JUUUFQrC4OaH5SBdq10YVFcvXJuhKIRfG9XEbLpYfMrt6gioqynlOPsnoPD2gnOcU08zswC8dYzdc8uOYNM6plGL6whFSKTzfZTFa0g0dWk+ukU9S8pMElEalJnjfG01YV4r2pQ79r9pGpiXTTx/idn2Wr02MmzcvQLBy0aq4wHJ8ws02VS4JBg2wBG7DoyokQgh0pUAIVFHhbzZJRYzfD7EcC6fhU8wzgmgHx2mjVIrjnLWUpM+V4p0QISycwEUIgRO5yEaJTEvj7uQmyJXLgvRwST7JsAMbtxVg2QJ7fY7jdAGN0/DwZEV6tAQh0FqRZbugNH4vRJUmdinGKQgIN5sIxybYbBJfn6Bqa6LKimKWYXkO2eHSPFcrJUqTHC7oPDWgmGb46xH+eoPFtRGtp/sMXzgEwLEstFRIZVylfJIS7bQQlkAVEplIktsztNY015u4nYB8nGLVFkDOCoQtELbAjhzCRzpUWYnbDXC7EAwa+P0IlKa58QjZ8oDZayM6T67hhi1su0U8vovl2rQGz6Cqq4S9LgDx8Yj29mXiyR2EbWF7Nn5QEkWXvtAtep28r9ynL5UIYZnsTstncXNMMc/Mjr0s0MpkczvPraOlwvJsbN9BOBbhoIvnbSDljHw5IRvGCMdCleampcMZlmuzuDWhnGfIuETlFVprhGvTuNBGV4pgPcLybKafPjSLv9KUiwI7UGipsQIHO3DxeiHpUUwxSplbIzpPDdBa43cD46IlJdGgQePRDtnhkpNbI1zbxhuEOJHL/NUh2cGSdJ6RlSVpUaCUYv/2MdGhTyPw8bcaNJ7oUaXSKIUl0Bqal82CDvoRMivxWj6zayPcpofXOa6zZTmL21O8Toqwh4SDJo7ToyxHRP114uERtmtTzDKKNeMy2oFDtNXGcKPOIpp3W2H/PakUSlVUhXm0nxxQzFKqomL26pByUVDOMuzAoXGpgxt5APiNdaScES9u0GhdNvFHJnGaHrpSJLszWk/08foRwXpj5V9nw5jF1REyyEmPYuLbU5PhWhRIpRDCLMRynqOVRkuFLk1MoytNGZtjEYK5Nab9eJ/ZtaGpPSQlwWaDZHeO5dpYQpCXJXJRkA9jOs+uYzc8GkoZS3Fjys3jYzYGXfxBRLDVxG15BIMGVWFiA2EZV2h29YTOs+skBwtaj/WId2fk4xRVVizvThGORZWW2N6Di1uTxxPApHaVZzJoVVZS5ZLGpQ5KViTlHTqdrzjD3XofpWS/tCJNoSt0yU5i3KZZ+CgFlUYmkmKSImyLoE415tM7uC3fBMEtsAPXBNh5hSrVvZRkUdF+ZJvl4THJ3hy/F5E0THFM2ILOc+tUecXs5WPSuzm60qQnS4RlsjmqqGqFUKuskVyYAJ71iHyakg8TskOTDs7KkkJKcikppKQVBDgNj+w4wQpmdJ4ZML82Ij+eMU9T7qcCWL7N8saEqqjoPDVg8sqRKRo2fIpJRnKwAGHSrGVcIOe5sZyhS7w7o8pNIqGzOcBybaq8xLZNvOaELjIpsSuNTEsmrxxjuRbz10bYgYPT8N4Ad/DG8jAxRU3e+kUMO1EBP6O1/qkaI/dPMMzEW8Bf0FpPhOHk/hQms5kAf0lr/ak3u8Z7Uim00qbmMMvIhgkosysL2+ySTuQQbrdpXuowe22EE7oIS2A5FlVekSxvG0tRmIWupck+IQTx3Sn2EzZVUq4KeHboIhdGAbJhTHZs3K5KKezAxvYcE7BnEsuzKdJyZSmqxMQ7ADIp8bqa5uN9nKZHlZREqUR4FlSa3SsHVCZdg5zlyEWOjAuTwlEarTVKaxbzBG8txLItylmO2y2QSUE5zRGOtcpMAXjtgKowWSSZlASORZWUZEcxqqhwQpfl3Rle2ze1nkctVFGxOFjgNDzKuECXimDL1E2chofXaKKqs9UptH7olKwEfkBr/SkhRAvDRf9tDDf+d7XWf0cI8bcxheIf5PVA06/FAE2/9s0u8N5UCm3SnVUusX0bVYCuzG6kK20eSiOzEpkUoDSWZ5NPT5UpJRsmZvHUO3uytyCfZDgNl+XuDDtyAZOe1NLECqoylsX2HaQsUXVQXExT7MChnGaorEIpBbZYZaGyssQD4ptTymlGdKmD0/RAmFRolRmf2wJkreBZUeKndS1E6Tq1aZQiK0uKkxR5oUTGJZZvkx4tTQbOsVCRa+oaR7FJu9YJCGMVjXUoximWazG7OsQObLLQLPhyWaBKVVtGC2ELgvUGqqiobAvLqbBaPr6/+RD36+wxRY2bO8XOLYQQVzA26du5h3z4KAb18IPcBzTFMBG7p4iKL3SN96RSWLZN67Ge8ctz81BFxfLWFF2Zwp4TuRSTjCqRWLaF5dmooiIYGOjE6SKq8gpdKcKtpsEb9UNzDiDaaZGPEpKbU4RragGNix2Kecb8ypBKKXavHLC+3qX1zBp24HCwN2Sj28H2HVRZofKKsqroPdqn8WgHp+kT35qQHSzJlwVZYVyodhji2DaObVPlkrwsVxYs2mmjcsliGqO1JvQ8Go93KEYpZSFZvDLEG0QmhVxnw0pZ0e74VJnEck1qVmWmpiIsYx1bz6/jRC526BorEDgU89xU5jNJMckIt5uEm03CjRau28W2G+T5EWU+o93+0Bnu1humZAdCiE/c9/fP1Ni210nNYPwI8Ic8PND0/aUUSkrmr42QaUlV76YqNzdf1+4Hte9tBw75yOzk7ScNDs1t+pRxgfuoR3q8JL4xfd35k705lu+QHS+N/9wyro4dOsyvDcmOE8pJhmPblEVBtsiI0pLp3pRKqVVGSkl1L82aSRavjbFDl+7z6/gbDdLdOWFSUo4zilKuUJA3r+3j2TYqr4hvz3CaHsKxsS2rdkc0WhnLUUhJI2rSfLzH+BP75v9TVJTSbBTJKMVtB6hSUcqK+PZ0dczslRPs0MQHTtMj2m4ZKEhaEqw3WN6Y4LYD8klm8FjNhUEDtAPjbp5R3sB9Gmqt36jouxIhRBP434H/TGs9v6+dz+cd+kaXfLNzvyeV4rQwZdkWyhFYjkDLuuJau05aaRDGzVKyMgu0UiT7c9pPrOH3wtVxutIke3O8Xojb9CgXOXZpMFMyNot940PbpAcLqDTBllmEraRkcWVIXi/AsqrwXBe36eGvR2anLxSyureAhDAxkSorOs9vUGUlyxsTshtjJsslnSgi9Dy2Lg1oPd1n+sIRKjfuh9aaSmuaYYBcFhxdP16dNx+nVKk57vSzFGOTbJBxge3bJgbyHXSl6HxwA6fhYvvOCm0bbrVY3JwQrjeYjRK00sxePsYOHewa8uE2fSzXWN2zycOnZIUQLkYhfklrfdoE4mGBpl9Q3pNKISyLcL1hcEVpuYJOyKRc7aRoKJc55SQ1hqPS6EpRLEwVPN6bGWDfokBLhb8e4XUMbKSc5yyvT6jiklJWVEqx/NyYvJSr84e+h9sPSIsCz3UphqnBIQHeIGL+0glOywMLZFVhORbBVgMrMDWT/NiADWevnLA4XjBLErKypKk1cZaZav2iII1rjFRaEnoeWmtOZnPcZUyc51zaXsfrB8bFq3fTbH9JWSuicCymLx7hr0dUSuE0jbuUjxOq1MVpejhSEW23yIYxxTQlXG/gNn3s0EFYJuNmh8a9ml0bUWUlXic407162EC7zib9HHBFa/3373vp13kIoOmbXeM9qRRaVsyuGX6DjEuqtERllXGltL5nLSqNKtUqnkgOFsjYwLfbT66R7M3JvZRymq3OHaxFpL2QcLtl3LKyYv/jd02QXdclQs/jYDyhGtUZIaVQQxMErzWb9663O8frh1RKcXx7SHS4oLndwglcymlG5tkkw5hllpEWpu5x5+SEdhQh6zpKmucIMG6S76O1JnBdKqXoRBFuLyDdXaAKRVWY7z+czxFCsPvaIZZlYQuBdTzDEoLhy8d4tk3j8S524KyKm8AK+SvTcuUCOg0XGZe4bX9Vwfe6gYGKnPV+PZyl+Drge4DPCiFeqJ/7rzDKcGag6ZvJe1IpLNej++w6xSwzKFKpSI+W5OOU0YuHq+yTKk3QaYcOyxsT0r05VuhQLkMsz6bKJNnBEit0UIXC74cU85zO02umGHh1SHJnhu+6dD+8SZWU+IOI8ScOuHhpAyEE3iCkGKbIZUFeSm6fnBD/q+s0g8D4/LcXFFLSbTRw1wL89YaBg08zmk/22fiaiwzKinKRkx8lfO7mLlprvIbH7RfucOGJTY5vGbj7rZMTKqUIfZ+8LEnynBc/dQ0hBLZlcXFtjawoePSpHbw1AyfXlcbpmDpOeneBv26KflpWWL5DtNVCVYr0cInlWpSLguzEZK200uSjFLcTkOzNTVYqvUd6Ops8nPuktf4XvHGcAA8JNP1C8p5UitM4Khsl2L5DlUvi2zPywxil78UU91eX28+smYKTELgNl9nVIcUkXaU0T99TLnLKRU6w3sDybMILLarYFOU6z62THi8N9FppOh/ZJB8mzIcLRF2N7jebeI6D1prd8RghBI8OXk80q1KTXcqOYwDSu3NmScJvfPo5fu0P/yqTeI3N7ow/95GP8W9XLwIghGC8XGJbFld2d00lXQjWWy02+gbSgdKriniw3aTzwQ1kXKz8/2pZ0rjcNZiqOkOXHi3JhgmqMMSnU+SvHZjYAzAkqLmxpuFOG6/jr3gaZ7lX59ind0CUlMhMUi4MeQetaT+9xqysSO5mq+zTqWIoqUgPltiRi9M0QWX3uXVmr55QLUuotKmG10QiXSmirRb+WoTt2yR35qA1yzsz0rtzY4mEXhX8osCn+cwaVVaSH8SMx3MmsUmfVkpxPJuRFgXdysDChWNRlCXFKAVguFjw8uyb+Oj/+y3kpdnVj6ZdPvp734Pv/DJf/8wnsYXAd10e2zCZyKwsCVyXoizxN0w1Pttf0u23cNse+XGMjA2MJOjcg4SHm01mV4cEGw06vTWsOnWcn2apcpNG1soUDIVtUS5yqlRSznKqzKSwz6oU5lacY5/edtFSMfnsEXKeozu+gVeDqU5rcyPtwMHvR8T2FJTGDu5hfGzfYf7aiPwkMVyBwEY4NjIt0UpRLgxrr/3kGsn+HDtycDsB/lqEEAYTpDX4/QhdKrxBiN8PWd7I8DcbbLQ9BlmPbJbx0p07NIOA7QsDGo93SXbnTPdn5FKSzFNkVTFLEv7Bx75upRCnUlY+/+QP/jzf8Oyn2Ox0yMuSyPPIypLNi2tMDkxwbfk24XaLdG9hiE6Vwq7ppSoPsHo2VSppPdEnHyfIRU7V8amKimKSUkwyymluYpLUZNJOYzKEppybYD+61CZYi7ADh7S2cme4W5xjn94JsYRJMTqWKU55NqKuICutsSOX2ZUT5LJAeBbpwRJdacKLbdpPrLG8bYpxbi8ESyAXBU7kkuzNqXLDtkPD4uYEr+1jh6YqbAeOYdMlJWgTmDYv97Ajl/krQxbHC9I8XyFa89Jkw5pBQDxJkC8WtJ4b0PdskldNguQ0yB4u3pifMFz0cGzjxnWSBLftY6U2wUaEdTSnqCpmr42Rs4Jwu4nlO9iBvapGt5/sM3vVxCSdZwaGrZgYCEhysKCY5zgNl2zXpJtlWSFcm3wYr/6vp9Xt9GBJfhKbFK79MMy7c0vxtovl2jXVU4LWzK+NyI5iinG6Kt6lewviRUqlFM0gINhu4vdCTmtAqoZWUOOoLM9GzxXJzSnR5Q5u22d5a4LfC3DbPp1nBnjd0AScUoGA9HBBlUucyKXzAdPlpddaM9mwUpEMYz575w63T0547uJF3Bp5q6WiFYa0tlpESUgzCNhoTzmef75irLcmOJaFcCz6/TZ2wzWwjv0lAM0goPO4qZYLS2CHLrZnU+UVCMhODC9cCKPEVV5RJea7276NyiXLV8fkUlLlFbKqiG9M0KUiTwraNQQdWGWrToPws8q5UrwDopUiOViQj1I6zw7ofXCTdH3J9MUjFocmx996dkD5wiF+08NpecQ3TSW3KiThRoPCt1nenJp6QcNlfuUEfz0yPvUpVGKekx7HBOuRAc7dmZINY+TSMP1ULkn3Frgdn+YTfYJtQz7CEuztnzBLEmzLIvA8U5hTCsu36XxgA38QGb5GKvFdl+/+N36Dn/6d76SQ91yowCv5T77l/6ERBLhtj+hSu2bLVaQHCxMPgenkAVieY1LQNfdDZiWzzw2p4sLgvPIaA5VJinGK7dnkw4RlZoLo5efGNcjRocxyHMvCH0RY/r1llJ/EaKVpPnL/oKU3vVvnzLt3RgRKKuMbZ5J8bAJWy7PRWmM3jLtjwQrH5K9HrzvDKkOlNJZrkx2am+2th3jdwMAzlgXFJGXwVRdqrnYXlVcEaw0QkOzOWF6bEO60TAudtDRWpNJsdjpc2Bpw9dYugesyT1NaUUR+GDPJJI1HOxAbmEohJd/w7KfQWvNLv/9nGS37bHamfN83/S5/7k/dQi4byEQS3zrC7QYEWw2C9QbZgbEWwXqDZG+BykwrHKfhUkxTmo8ay1PlFcJWqKKuvMtTxTcAx1JKBls9VFbR8H2ELQgvteo6UEGjrklUaUnj0S5o878+m5y7T++IaKlWzLXZlZMV4M1uumitiW9MyaUkDH1Goxnh0icMfdyeD0Lg90LyUUp+GJNLyWJ/gtaatbImFp0kZCfJCn5dzDLycYpWmvRoSefZAdkwoZzlK8sy/9yQzrPreGshKpMMXzhk/+CEtCho+D7L3ASrVnjvllRpSf9rdvBvz2hNMv6E/DiPrv0WWVnSCo1bNbnRZ/1D22R7Ju3r9QLTMM13TJX6tNFBUeENIpqPdnFC03NqcWtCMc6oktIUFEtVY6BqclUNSVcAStP749sU45ToQts0akhLws0mbjvA9h3KhWEjRjvtVbOGL3qvtLHs7yZ5TyqFkhXzq0OqRFKOMsrK+MKVUjRDMzl3kabM05SG79N5pEt0sW069m02mL06JNppIRc5zWYPGZfsv7KPrvP54+tDXMfBdWzim9NVoF3MjGsmlwXCEjgtn7KaoqQiP0kot3Py4wQsiAYNdiyjrBrIioK7wyGDvMXaI3200sSHS+S8YDlP6D3axz22EUIQ+T6X19dphiFe6Bp3poagV7mk9XSfYLNF47KxBPkkNfWF2Dbx1HF8r3hZmBQrihq1K5FKMX9lSPcjm7jdAHVoOoJUSYm/FlHMM9pPrJEeLsgnKWVcomWF2w7oPL5NkSwpFxmcET3+MPHHOyHvSaWwHOOXy6Rk9tIx0UYXXfd9siMXO3RwXzohnqUUUq469iUHizomKPC6Id5aRHxjYvxtranyitFsQS+K6H1ki3JR4DRcop2WKbhN0xUMIh+ZhSirivkrQ7RUlMuCYpgwOjEsuUZd1dbaFNV6jQatyPR+SvcXxFnGNI6RVUV05NNrNtkbj5EyW7gOAAAgAElEQVRVRS4lmzstgs0Gs88es8hM98Egr8hPTKsemZR0nl0nHyWrtjpZ/bvl2hQz01zNaZk4xUDRFWVVMV8meLdNh0Nd13Qmnz7Ebfum3U4vXcFU4rsz/H5EtNMmX9Q9sM5a0a7P/W6S96RSYJmOd+XMkIKal7vIpCQ7WpIdLilnObpQeLaNrCr8QUQ+Ssn2F6hS4TRMJdfvG6tSZQaGgdKstZoEF1qAKfDZoUN2Epv2lfIeffWUatrebHOyO2LziQ2EI7BCB9dxGLRapGWJY1krS7Y7HpOVJVtA69k1gsMFw9EIWVUUUuLYNpHvr77m9VfucuGgR/PJHouXEuP6bUT465FhzpUVycF81bRNFRUyNvilaLu1Oo8qKnShWFwbE+40CY5McXHx6h6WEFiWYep53QC3HxBdaJtC5Cg1m4xn4zQ9lrenIMDvhSa7dUY5rYy/W+RtV4p65O0ngD2t9bcJIR4DfgXoY+a/fY/WuhBC+Bju7Vdhhh5+p9b6Vn2OHwL+MlABf0Nr/Vtvdk3LMSnZcpGTHC4MzTS7F8wZ/oNkd++YfqNhyERJaQLwaY43iGg/tUZ8Z0r7A+sIIVjemDC8aYhD3QOBcAReLyS60Db9oYqK5bUxKjX8b68bICzB8trE8CWSEi013Q9uoAvF+HhGkucs05Q4z1Fas9Fu0wpDvEFIcneObVmkhSEajRYGI1VIyeW6am0LgdcPDSDPMbdyvj83bldV0X/awEe0NIve8h3mnz3GaXnMrp7QenKNRVxQZZKD6ZQL9HEaHo0oYLxc8tiTFxCOQNgWulI0HuuuGItUGjnNWSQjw1o8Me10rMBkrE5bcH5R0e9P9+lvYoa1tOu//y7wE1rrXxFC/EPMYv/p+udEa/2kEOK76uO+UwjxPGYw+gcw86h/RwjxtH6TPJ5WynToyyWNnbbhVrgp4U6LclGwvDZmNl6gtaaz1SHdWyAcC9u3V5VeGRdkRzGtp9eYvXSM26n7rNbBp7As3IZnyEx1sav5VJ+Tj+9heTbzV4a0nl3D8gxXe3JkoOjeIKTzxzbwDiPWJiYG2TsZ8bn9exD/KjUuXVoUDFotes0msqpI8pxP37zJMstoBAGXtgaEF5osr0+ZxgYqvtFu4/k+XjNAZaedCDVlZeKFvJR4foi/3kCVlQEqSklVU2SLaYYdOiilmB7OVpYiL0vKWU6wYyYPa6mRStG+2CXcapq2pK5tXFTPPnPxTvPuU4q3e7zXReDPAv9L/bcAvgnTgRw+f2jL6TCXjwHfXB//7cCvaK1zrfVNDAT4a970wkqTHhpXKD2OmV09oVwU5DWWqPlUn7CGWWupDLy7ZopZnvmXlMvCwBtmGcWw5lwArSBAuBbJzSnTV47JTmKW18dMP3PE5JMHlFKaeGCSMP30EXbkIquKtUt92s8P6Dy3zvLmhPlrY9xewHyZME8MDGWZZTT7DRqP9/AHIVsf2ObRp3eQVcX+ZMKNoyNUXQG/tDXA64dMXzzm6GhMnOc0g4DuepvGox2CzQbtZweGxLTIDVT8ygFFaSyW5dmmm6FUVMoQnezQIbk149r1XdR9XUGq2n0bj+ccvnLIydVjxteN1SxOEvJRco+yGhkOxunm8kVF61Vnk9PHFxMhxM8LIY6FEC/d99yPCCH2hBAv1I8/c99rP1SPjXv1LKOT325L8ZPAf4mZBQ2wBkzvG2t1/wCWFZdWay2FELP6+Au8fkzuFx3asrO5ZuKGygTH+eHSuEZ5RTY1AalTUzevXTdQbN91aeUhrTgAYdh62SIjiguz4BxBOwq5fXzC5WjTQEkCB78f1m1rTGeOSilO7oyQSpkg+dhkvWb7M8TBnOZaAzt0GM7neHsuk+WSrW6X/clk9V3SvTnhTovRC4ekRUGS57SCgLKqWGYZ8yThys277Mz6bD63iXXbMn5/VXHt+i7NIKAdRQanlFckk4TmVotyX9K73Ce80DKbAab6r7XZ9Y8ODGpXA49vbuD2DZQdrZleGeKFrmmoVncEyUcJMilJ787JjxOswFhaOzTASs7S9gle15bnjPILwP+Mcbfvl5/QWv+9B9bFQ3sab5tSCCG+DTjWWn9SCPGNp0+/waH6i7z20ENbPvjsY9qOXOTS+MvCsZDz+yDSSlFIyVqrRaff5HM397jQ7+P2Arx+QHSpw+zlY5PirN0YmZiuGUprdKGwmy7pwZJinLL2NRcpNlLmV4foI22opjUk3Y5cTu6MEELQ7DcIdlqcvHjAMsv4zLWbZEXBneHQKKptcvv5SUJ0sb1iygEkRcHeaMROv8/Ffp9ep0Ww3aAYGuvn2jY3j454ZmeHtUf6Jrs0yZiNF2RlSSQbphoducS3pviDuobR9BBCoJQicE2r0e1u93X/2+blHlUucZuewUxZRjGcloflWqsah9c34wzcls/DrPPTAuqZj9f69+qmBWeRlacB3BRCnHoa/98XesPbaSm+DvjztRkLMDHFT2Jm2Tm1tbifL3vKpd0VQjhABxjzR+DYWq5F59l1w4yrIRnmYdwFXRp4c5VVZIfLz9upsqMlWmqyomD3ygFpUaDLCqfhoo5ff6zbDUy/pEGDYitDK0243UQmcoWfKqRkmWVYQhBcaNHsN2inKdu9HrZlcTSd8ur+vknN1ojT2UsntB7v0vUdjl88YJ6meI7DeLEg8jzadb3l+HDCzhMbJK+apgiObXN08wSpFJHvczI3rfGt3REN3+fopQMqpfD35zT7DSzfXvE7llmGbVn4rktRSsSsAGUaMDce6xllsC0sx4AJ/bUIy7GwXNNCp/VYz/BRmh7ZKDnbKqndpwfkTN083kD+mhDiP8Akdn6gnpF4Jk/jfnk7h7b8EPVwldpS/C2t9b8vhPg14DswGagHubTfi9Hg7wD+b621FkL8OvCPhRB/H2P+ngJePw/qQVGaYpaZglVerUB++ShdKUnnuXWmLx4xnS5RWpuO34czOhYEGwa2MGi1iPMcJwy5/eo+jm1cjVxKrFlF80KbxdUR5Swn3G6axmazguHRIVlZkpcluTSEoc1Oh6gXsbgypPOhDdYXBY3Huxy8fLCqMUS+T1aYboGdtvE4y2lG5Ptc6PcZzufIqsKxbbx+SLq/ZBrHbCwKLCGQVcVnbt3Ctow7ZVsWnSii4fv4jmOoq0LgOg7NtQZux2d6c0JWFPRbLbzaUvmui+c6piFB6OA0PbLDBcXYdEa3XANAdBruvfke3ZB4d2YmI80N4/FM64Q3DLS/aDePN5CfBn60PuWPAv8T8B/xZdLN4weBXxFC/PfAp6mnp9Y//7favI0xfiBa65eFEL+KmYAkge9/M38QTIeO5S3TWKBKpeFnF5KirgfIyiBB7cCh221yOJ1y5fZdGkGA2tP0675H/nrE/rUpTd/HtkwW6XSHHi0WzF9L2djo4vVDvG5odsleTtBo0rUsyllGOcqYp4YXce36Lq0wxHrVxl+PkIsCz3GM+6I1rm3z6v6+gZLnOZvLDofTKaPlklkcM0sSGr5v3mMLdk9GLNKU4+MpoeehtOZDly7hOs4qa+RYFm4vMGy7nSb5UYyuNNEjbbxuiNPyqdKSYpJx47U9GkHALI7Ne5cW9rFRsFOxLcv0n7Isk4L1bIRnYfsmg+d2A9DaNC54/gyrQT+8+/SGp9H66PR3IcTPAr9R//nu7Oahtf7n1HPqtNY3eIPskdY64x7Z/MHXfgz4sbNeT9iWKTClEhkXOA2PfJjQAMpJxsHekL1942LIqlr51K0goH+xh9cLGL1ygu84NDyPtCi49NiWyagI0KXCPraIaouicolMS6ILbbxOgOVapEdLkhpj5VgWed09ox2GtJ7us/+JXTzHMZxq10VpzSSOafg+F9fW6O50cCKXbc+i12xSlCUv3Lq1qoDbvoNn28RZxu5oxMW1NSql+NzBAa0wpB2G9JpNWo92cLumeYEd2DSf7lNOM+zIZfriEZZvkx3F5nPXyQcwcZdTK4NSamV5rLojCQLcro9wDbxcK41KDZPP70cPAQh8a1KyD3T9+3eB08zUQ3sa78mKtuVYdJ4amE56I9P+MthoUKUlCzkm8n1a3YbhGddo15fv7prdse1z9NlDxsvlaof3bJuy3kX7jQbdj2wZOLYtkLOC9jMD8nGKE7lYjsXs1SG2b1rmW3FJtshIarfItW3SvSWTOOZ4Nlt1ANRac3Vvj4bvk5UlH3RdZknCcD5nkaYss4xlljFotei3Wty9uo9t26SFyY6dzGYGEOg4PLW1taq7ZAem1b+/2aBcFHQf6YLWZMcx5SxnmWX4roucJJzMZrTCkEcGA1oXO6Y2IwS6rOrZFhYyLbFsC+Haq+lHXq/OwNWxgUzLsy+sN44p3lSEEL+MaZE5EELsAj8MfKMQ4iswrtEt4D82p394T+M9qRTCMq0lZWzgDMs7M2RWktydE15o0TxO8DcjFjemzJKEZd2t+3g2o3qxYuvJTcJ9l0JKvDDk0sbAzIpreWAbVl/n+Q0W18dmt7QE+Um86kRYznJU6KwaKIPZbSulDMJ1c0BnP6ITGbi6bVl85tYtAD58+TICcD2H7c11WgcBcZZh2zYv3LzJ3niMY9s0fJ9+q0UuJV/9xBM4ts00jhkvFnzm9m18x8FzXdNpJIpYa/smjnr5mMVdU02PaxZgUZb0ms1VC55FlpHfLFeuUtg1eCy3G9B9foN8lNC42CGvW/+Yv42VRBuy0ZnTrH8E90lr/d1v8PTPvcFzp8c/lKfxnlQKJSXx7szMYysqRD2PrZxmNB7pEOw0aT2xhj+IaB0ZUtCN1/ZQStFrNXE7PpPbhlDj2sZvVnlFtoxJ05xqWdJ8Aho1kSY9Wq5GdKnUcBbKaUbnw5ssXxuzuDNmvFyuYgeUoh2Fq897OJkaRlue88nr14l83zDmTiIuPbKJM7MoqmoVN+Q1nbXbMGnW4WLBBy5dpBNFXOj3KaXEdYx75TY9skWOHdUcisd7+GshxTgzTZGTkuHxlOtHR1x6oKuIbdvGpSrv7eRVZoqTMi4I1ptYvm0ISaFDerzEcm0z0enLuKL9nlQKYVum7WVlSPXJ7hws08JlfmVI+/nBagoQSrM3Mou2HYarnS5wXULP4+5wuNqFfdelHYbIRUExzQi3WisK52l/KaBebCYlq0rF2sUew/ncQCWkJB+lNJ8y04XKaU56VKxosV9x+TKeazI3YcPH8m0OplPSoqDTaPBYnUo7nJoBLUprLOClO3eRVcV2r8f2Rh+7abqEq1zia5NRS+7M6Hxgg/jmlNHNEZM4JisKk3LWmsPplH6zyVa3S/uJHl4nQGtwQgdVVLhtn9nLx1R5hdsL8QeRgdPU1tCM9jo99uEq2u8meU8qBVqTTzOyo2XddkXiDUK89RA5N20wLdeiyA1KdbPb5WQ+px1FhJdappU/91rbAzy5tYVbD2f31sx4rfR4aWidcUG00yI9WFCMU/KhcceKacb0cMY0SfBcl6QoKKuKalniPdlHdzXFJFtdJy/LVdC89cFtnJZv+ND110qLAse2ubK7y9M7O+RlyVqzySxJTG1BSg6nxiWMfJ92GLL9x3YQro3XCZjNjymmKcFmg8b+ku5OZ6W8eyOD0L3Y7yMci4OXD2iHIeF2E/+5dWafPabz4c3V7A+vGxDfnZlhNHUH8mi7ZQJsIVaQmjPdrnNL8Q6IEDiBg7/eILrUMTt3IZnePcJyLDME/pbxq+dpSlzXCVzbRi5L5LLEFoJeo8H+eIxSiqPZjKBefNXhjIbvE+w08Vo+yd0Znec3VpdXtct2OqEoK4qVpTltOQOQ7i5w2z6e62IJQVYX+ZLCtPs8hU7sdLuM4xjXtlcMvWYQ8MhgQOC6Zr6F4yCVwsIodMP3aXRCvP4pWzBecbYbj3Qp57mBm7xwyN54zMFkgmvbJHmO5ziEnodUis6+xvId0nlGY2GuLRyDGla5JNhqooqKbG9BMUpqmIf5359J9PsQOv6lEF0p8mlKuNFkduWEfJQipyawDF0ztcgbhPQ9m2DpEQcBt46PCVyX+GRJISXtTgMyVpYicF08x8F3HMqqwt+MaD9rfPBiktWdAwvy44RlnDKJY1rzgO0PbCNeFaSFcZGUUqb9TSpZ7s7xGobgo7TGtixaYUi30cDrBZzcnRIE5vW8LO99v/uC2Ibv0+40cBpmNp/bDchPzCSj6FKbcLOJrrSZ7V2WLK6NUaWqOx86Kyuktea5ixdp+MZl05UBDTYe67J8bUyS5wxfOCRsB8zGSywhsG2b5MgMrle2Ilxv46+FZkzamdtmvjV1irdS3ptKoTTFOEMuS9pPm9SsmUFX1JOA7qUOAUopudDvG0ZbvfiOTiasd9p0Gg3uDIf0mk3TcExKOpe6OA2XZHdmGi0vS2afPSbYabKcJwyeXCe7UpprSY0lBM0gMN07bBun45PVzDpgVXu4/yHjkjTPSfOcned3uLyIuPHaHuPFAqW14WJkGfuTCYHrEvm+adFvDeh95RazF4/JPDOMPlhvmKyYNJOdhID8MDauUV3oA7g9HLLWbLLRbtP7yBZ26FJMUuJFSrfRQCnDHuxutHHaPsIRUGn8QQTCDLvMRylu08eJzljRPmfevTNihrrnVHmFvxYaYGAiDTzaskj3TL/XxqMd5M0JsyShGQS8ePs2Smsurq0xXi6plCLyPGRVsdnp0Bm0uHZ91/jsnkdvs2OGMpYlxXHKRssjznP66l4BbBV8a43rODR8n/H1Ib3LfdPXVSmavo8Qgn6zSaOuZreTclXbqJKSk90R7TBkp9/n9snJ6rueTjc6Rf1WiUk9L8cxYSrx10LTuEEIiqqiys18u2WW0VgUYItVVuxCr0e30SC42DLd2uvRZZVSzNOUwSN9wp0Wbss3Vqaq51nU39dteViujdcNHtJSfJm4T0KI3wT+01P225eTaKUp56b9SrI7Jz+KCXZaiJM5jmVxsjsy9FLgYDJhrdWilJJLgwF3h6Zb3iJNmScJSmuzS2pNFZekZcmg3WbzA9uUkwwlFa2NFvu3jxneGBpE7bJYDWLJj2L2xmOOZyaGSbKMXrNJZ8tYHauqCOq5EvdLlcmV1aoyyXi55M5wyDxNUXWb/UfW17GFMLWPjZYZDP9031iJosC2LOZXhmZEcuhQSmkmLEWuceeSktFswcHEdCtJ60xUsFziOg7djTbBdnNV8XeanhkhsDdf8SUs38FyLcKtFs1HugY1a3tUxdkGQb5VMI+3Ut7MUvwC8M+EEB8F/ketdfkmx76rRNgW0SNtTj57SPXamLwsiWepydBUFcPFgqPZzBTU6sVYVqal5vOXLmEJQVwv3sB1+fTNmyzabRPU1u0uVSbZu3XEpcBMSm1HEQLT2Pj6dVP9jrMMp+XxtHcBdUtz6/iYjU6Hy9ubxCfLVVDr1zCP4/mcVhjy6NYGi9GStJ51V85zHtvYWPEu/uXVq0zimKQoCFyXwPM4mc/xHIdHQ9Olr5CSzYu1j98OmL54RFkZdlyVyhUsPqv5GqcU19N0sG1ZVIlhAJZSEgUBo1dPVm39o0GDcpJhN13ctilgep0AmSr8jqDRfuKMd+vdl5L9ghUWrfWvYobstYFPCCH+lhDivzh9vGOf8I8gWlamE3gtbh0gAxzPZnQbDQbtNs89eonI83jiiQvs9HpcXl+nt96mM2ix0+9z4eI646VpKNaoGwZkdU4/HyZM4pjp7QnNp/s0N02L/a1ul0kcc/PILEIZl+wdDleDVMbLJUVeourhKklRMGi32Oh0GM1Ny/0kMW15irI0MI8so9KaG8fHK/bd6WfJynJlFU5FZRVFZRoVLK9PTRrVEmbOXWkKdqeW4nSPHs7nTOu6ReB5DJ7fRNimj+6ppfAdB7se8lIlJW4vMFNcLTPF9bS5dJVLlDpjSla/vvHcuyG++GIxRQnEgI9hz727VPoLiLAsWs+sUX26NBN5QpfsaMnszgjfdbn43A75sYFlNIKAbJqx8aFt8uPkdU2Qxzf2cGwbpTV3RyMKaXbYoqrIk2KFR7q/vZElBNu9HjePjtjodMysilouDQYs05RSSsN7lpKiNCPCTt2nU7hFWVNA4f9v781i7EzTPK/fty9n32JzLF4y7cyqzOyqroVuNs0Izai4agnBiJuBHuAG0RfcMQIkpAFBX400EgiBUAsQO2pGGgHqpkFqeqa76a7OqurcbKftcEQ4trMv375z8X7nszMrXRXOqczKcvmRLDtOHEeciPO93/s+z/N/fn+xiy19n4Zpst3pcD6bkaQp7xwcUG/aSIqghBRJjt6zWZ2tiBMhYwdwH83QexbJvQw/jrER1awsTKseyfWNDQatJnrPQu/bREOP6XRJzTPRVJVVELCz3aN9q5yZaOjC4UiSyJMMo2uh1Q38S5d4FaKYQ64SRUGVd31V4iflFN8D/i5CZfirRVFccWrk5x9SSe9QbA1zs15tz+s+QR4KYFgWZihHKo2v9aEoROOtnIEIkwQ3DCu7LoCGZTF1HIxS3bquACXLiMwXE3phmQckWcb9szPeVg/Yu7HF4nJZ5St5USAVBfNyF0rLo1teigJlSWKr3SbNMpq2TbtWIyp3jfX/79TrHI5G6DO1mpvYutYTGJtMGD0GQSSOUTt14aaU58IKrKyyxWtv8WfymeX5khaADF4cc75YVN4Xw+GcnpdQu9XBf7xAsVWMjRqyKlOkOVrdIItSKAzEnNhV4qt3fPpJr/zfA/6loig+/LJezM8qJEmI9vSehd40SAPBLKoHKf4qRCoTQ8XS0DumgJrVNdrf2EQ7XJD6CXGUMFqt6NRqnM1m7HQ6LHxfOBCVu8Yap59HKYqtYvoCUuDHMfv9Pg8vLwmiiNHDJZ1arTrizFy3MmyJU5FEX+t2uZjPq8WxZj0dj8f4UcSdnR02mk0eDYfkeV75WrxzcEC30aCx3cAfemhdk6RE4bhhKCpHj+eclvyoLM+r7vnS8yo9VRDHyLrCdOrSLJrCDzDPads2uxt9MWzUMtC7Fu6DmbBKroubhWyoIq+QSolLnJFn8dXerM+RaEuS9DvAetz5rfKxLvA/A9cRKtm/URTFvIRf/D2E750P/GZRFD/4SV//uYuiKIp/5oVe6VcoJEXCvtbE6NfQ2ybxMkTSFGqvdZGOFlVi6D1ZohgKwcmSIivQexbNtwZidDVMKX4Endt9tI8Vpo6DGwR0S9xM07KYOI74fpqCc7qsvCSC8oyf5TmHoxFeGPJElrENg7wo+Pj8nLwoaNl2VfYdrVakJVN1DRJIsgxdVbm1tcXUFVN2dVN0qPf7fXa6XVq2zcwRuJ4gimjkbexyEOnhxQWDVoud7R7NwCbJMlrtOicXopGnKYropZQL9N7RKXmeE4x9zJZJVip7FUvFm/toyxD3ZIle00nmIXrXpMgKgnNHYPtLI8j16O+VooD8xXeK/5ofBxf8beD/KYrityVJ+tvlx/8O8M8jZiheR7ij/ufl38+Nl7ZPkbixwNMsA+r7bcwN8YuXVRl7u4E/dAgvXbS2EL0hS+g9C62mC5+3Sw9DUxnfHbL5zja1UZ3UiQkCUWo8m82e2g8jehKmppHnOZfzOd1GQ0hBdJ2p42BqGjPXJUwSIesu56LPptNKhCdLEll5pFnvFFo5M3EyFhfy9cFAIDzznKPRiCeyTJym2IZBr9GgV7o2bTSbjJZLdFVFNlSyLCPLhF94nCTEacqj4ZCaYbBfqmPzPMfSdWEJVggEUM00eXIyZBUEqIqCpihoSwVNVXE+CNA1jVrHJulF5IOnC6JIXwCv/7MBF/wGYsYCBCrpDxGL4jeA/7Y0hPz/JElqf2og6cfipVwUkipjlUNF/pOV8L8uSXj1622W9ybCxD3NxRxEqfJ07k4pyg5tUSIwvcWS0XsXFIClaTjl4JFdHjviTADFNt/eYnFvSqNuM1wu6TcaFEVBv9HA8X0OBgOCkvS32W7TbzSqZmHNNDE1jYZpsgwC6qZZ5R+KLPPnDx4QxLGwHn7m/G/qOn45d92p13nt+g6LqUOjbuOFIWmWsfA8zo6GwogyTVms3CqRtwwDv6ym3dzaAsDQVPS+hXvhiKNVnqNrGh1ZZnu7h6SLmew8Epwo2VIrjlResmi1hk7sXK1PURSFsCf4ZHwecMHm+kIvhMH8WoxWoZPKWIMLfrkWRZ7kJKtIQIZXEakfE448FFNleW9CNPZIFhFqQ2d6Pq/mrj0vwHRjsiBh9vGkOg4tfJ+4BBBE5V12syVmKbbbbbyJx3K4YvDmJuGFi6XrtBoih2jUbRpzm+1uB6WmYZwMaVoWfhxXlaYsyzhfCNOYlmVxNBpxPp/Tsu2qE25ommi+ZRlaCRiwdZ2NVos0y+g3BOhgtFrR6jaYusJAvlUm6u+fnNCybbr9FqPV03L1t27dxA1CmnstsiBFaxqcf3SOG0WcTUWT882DPWHj5afIWQGIBFtr6EiajGKo2DtNnMcziiTDfTx/MWzmjy+KzwMueF78QoALvvAo0pzFR2PSsiqUhymZF5N5MfXXuhQlDXB8MiVKU8x1daknkJDmZp2BqdJ2YtJVhD/zKxWq4/s4YVjd5d87PqZdqzFoNqk9NtB7Fpauo3dMehs26TJi0GhQ5AK8Nvc8DodDgjjmcj4nz3P+6O7dahfIy7xibQ4/Wa14c3eX64MBXhwjAX9y/z473S77mwO0pkEyDzF36jy5dy56DY7A6SRZxni1YtAUxNI0ywSPqkzmVVlGNlUuLxbUL0yiNKWWFSxKh6WdbhddVTkdTfCiqDr2aaqKeSmm+nRLw9yqo9o6qqURJh7WZl3ooa76fv1sehPD9bFIkqRtYFQ+/tUEF3zZIesK5sDGD1PiuWhYpd7ThnwWpKROTN2yaALBWoGaC9SNJEskywhJF6Xdxm4LSZWZPZpUJde9fp+V71dDQVmWUb/dJY8z6qYp8PaSmGvea+0wPpzghID6x0gAACAASURBVCGT1YqtToep6/Kd117jpDwmWbqOrqrkJX/pg5MTPjg5wdJ1Hl6KmfHNdptBs4ltGByPx6yCgM1Wi50bG1x8fEmW5zhBQBDHWLpOzTDwo6gimMiymCGpmWZllOIuPCarFWGSMGg20RUFNwyZuy57/T5RkqAqCre3t1GbuiB4GGolES+yQrjDNg0SN6osmNd83Z8aRfGJyb5/jFgjkn6bH0cn/ZYkSf8TIsFe/qR8Al7SRUF5Tl3X7PO0IAtSfD9Ee2zQuN3D2m2QxzmLH14y97zqCAWCIxueu8xdV3Sc/SZFUdDcbKJOFI7GYyarFb1Gg+FyiaYoopfx3gWtrRZNy0JrmUzePWfp+1XS3Gs0mKxW7Pd6TFYr+s0mWVGgSBLXej1AgNNWvs+g2eT/fu89vr63x/WNDWqmScu2SbOMjWaTrU6HrXYboy4skQ1NI0pTvChi6jh06/WqCLAGKFu6zmi5REL0Ota+GF5Z8k2yjJPJBEPT6DZEl11VFLSy0VgsC2RDwdzSiEYeWsugdtDG6NvkSSbKuElGNPVRa/pnvTOf9Va98E7xHHDBbwP/iyRJ/zpwwlMyzP+JKMc+RJRk/9ZP+/ov5aJIgxT/aEmwEM24x3/+mE69ztR1aQUtxv/vMZImY27W0Dom+VSUP4usqI5Zkirmor0oYnx6ShjH7Dl9emVVSZaEJ3fLtmnatqjUtCxkQ6H/T+/hnyxJs4xBp4XnCcmDF0W0bBvbNHlta4uaYfDW9X30rsnZoyHn8zlLz6u8KN7a3+cvj444Go0Etsa26TebvH1wQGOrgSRLnD68FJKOZ5qJiixz7+wMQ9M4HA45Ho+RJalS176+vc31jQ1mZZnXiyLOFwtkqBJyXVF4MikdmxSlOjbpoULox0I2I0tkcYp7JPIhra5X/hxrYPVPjYIX3imeAy4A+Oc+47kF8G+9yNd/KReFYqi03t7AdmPafoL3aE6aCS+31IkZLYRDjzITqllT01j5PpvbXZyzFbqm4gYh+3d2yMKUw4dn1YV5MpnQKAHG49UKXdMYdFroXZPjj8/ZdFuCfNEysAwdrW2ghjG6oWHbJpPVCsPQOBgMqN/pImsy4dDj2q1NrCc6M9cVZdDJhJPxmF6jwa/dvl0J9XbabSRJ4vzxiL03dth7Y4fMEyLEy8WCIIq4f37O+WwGgGUY/Nrrr7PwfeRSIp6kKWezGf1Gg8vlElWWORmP0RSFXqPBW/v7xGlKvWYh6zKSLnA2sl7+MVSKNMPcrBOOhJ92FqTiOJWu6eFXvft/ZvXp5xpfJGB5D9Fc2UJopv7Loij+3ufpPEqS9K8C/375pf+joij+G35CZFHC4r0h0SqqBvOjNKUA7h4/ISsT2nVzqigKtjod5qMlcuksNHUculmH4ekURZYJkwQJmJUyj4eXl7yzv0+v0SBNMmQ3wQkF4lIfebTf2aT1K0IVlawizM0azvGSumXh+SGDNzeJZ4FQqi5Dwjhm661t2tOA06MhK9+vmnlL3xdz21tdDo8vqFsWsizGXVMnRqlr1c+SltSPdr3OVqvF3BPS9bf29xktlwRxTNO2ccOQm5ubzFyXb928ySoQu9lkteJHjx+jKgq3trZESbbE5eiWhtrU0TsS9Ztd4Qx14aKXSXUWpKIJWlICrxQFL9yn+KLji9wpUgTk9geSJDWAdyVJ+gPgN3mBzmO5iP4D4NuIX+G7kiT9gxKe+5mhmBrtdzZFA28VUsQ5WZQyOhbnZRCJ7XpxTB2Hx6MR3XqdXlnaXPg+zoVTycXjNOVHR0esgqByDQqThOPxmPP5nG69XmmfMj8li1KKNCMLM1pvbeCfLKlda3CzZ2MMLGEHluSkjnAqmrkunbGPOxXHp4ZlocoyvWaTNMs4HA6pmyZ+FJGU/Yfxckm/2WSgtxg0m1yUOP9uo8H1jQ169TrD5VIky7KMVdIOkyyjXcpOtHJI6Y3ruwzHc1RFYbvd5nA0qlS4nVpNQOHQnjJiS0VrsoyQDQXv0q1M7lf3p6IkewVNRAHV4v+qxBcJWL6gbJAUReFIknQX0TR5oc5j+dw/KIpiBlAurO8B/+PzvneeZASXLkWaM/54RJSKmYAoSbCyjL03dhg9GjNxnMo+qyiKaiYhLwpWvs/7x8cosoxezjsAdMrhpJsbG+KubBhEScIqCGiXuYUgmguUTR5mSLIQ2jlBII4oYRt7T5hHlj8T49WKrVmHoiiYOg5N2/4ExnLQFMn+0vepWxbXul12Bj2Wjse9o1OeTCZcLhZkhZjb2O/32e12ef32HsPTKXb5OqnXsXWdVRBUKMyj0Yi557HdblMzTZqbTcz5nK2tHuPxgq23tsnjjNqNDsv3R9h7fRYfjVFMFS+K0HOL9p0+kgzIsiAlalf0A3qmDP1ViS8lpyhb8t8E/owX7zw+7/FPf4/KtGW73xGVJzem0bQxgoT6ToPDu6fsvrYlPKVVlY1mk7i0zYqSBCcImJZ6ps12u7pA/SjC1nW+cf06sizz/vExh8Mh/WaTjVaLvV4PTVFo7bQo4hxrrynQL25C6idIikT3tT7+R+eiEde38A6XeN5Tv7soSbh3dlYN/TQsizzPOR6PSdIUSZLoNRqEZbWoXasRhjEfn5/TsCy+fesWf3z/Pp16na/t7mLpOufzOdk0Z6/XQ23qqIHCTqeD3rcwL1bMXFeUW3d26HQaWLtioaZ+UspDFOqmSZ7l1G92WN2bEEx9LEdMFxaZ6K0UmbAfWM9GaHX9yizZAtGT+SrFl2EEWQd+F/i3i6JYPWtE8umnfsZjn8u05e03bxb1G23SQBxlopEnsDeKSAgbb4jy53o6xBuL7m/DsoiSRBislENFddOkAIaLBUbJd13HenBo684mKBKLhzOCKGK7J8zW/bmPrqmMT6bkZe4SJgmLx3PiJPnEYNBOt0uSZRyPx6KJNx5Xw1EbrRZvXLtW5QRhHHNaJvxOEJDlOeezGaam8Xgo8pGGZVEzDPrNpuA/3WhRW4S0v7lF6kQ0c5g4DoosM3NdWrZNNPLR+xbFKsLUhLVyfbNO/aBNvBSyjSASPuGiMZqIu3xpJyzJklgUbVM0777z3MviE5FfNf/4kuILXRSSJGmIBfHfF0Xxv5UPv2jn8ZSnx63143/4E7+xDLKuopQJnLldx3+yEk5BeYGsKdRvdVDM0u724ZQ8ymg6Mf4iQJPlykVo8/qAoijQDxVqgzrDh8tqdNUJQ0bLJbeGHkWc44chXhyTLmOml6K55kdipmF9hIvTlJubm0wch7f29qg3be4dnXJ7Z5uHF5fs9/ukWcZ7x8f0m82K+AFiRiNKUxRF4WAwYOF5LIOAD05OADjY2ODW1hbXNzawdB2zZMnmRcHo7pDubgfvcM58uCRMEkxNQyu5tJeLBfJSoj2v0b7dxxyvyMOM2o02iw9GJNOwkr1kQVJJvlu2TRamT3eG0rRGa1xN5rFW6H6V4ousPkkI6O3doij+7jOfeqHOoyRJvw/8x5Ikdcrn/XVKM5jnRZHkLD8akTqxmDGOxQW5RstnfkLztR6rh1O8WUDraxsEQxdlX0G/cKsZi+B0hXPpECUJG+0W3ligNbc7HY7HY651u1wfDAj9mPPZjEU5n+CMHDbe2aZ+siL1YhRdJYtTkjznwcUFXhQxcxxWQYAUiF3oWrfLRqvFbq/H8XhcQQvcMORysUA/PWWr0xGdc9vmDz/8EFmW6dRq3Ll2TfQRyqT5vIQwq2V/wQkC7NJjo3PQpQB0VSVOU6xyRzRKfVWWCx9xS9dRahpm3xYCv0VIXjY6p4+FL8a1nQFq10RrCVs0RVdZ3Z+Qx9nVETdQKYO/KvFF23v9TeB9SZJ+VD727/KCnceiKGaSJP2HwPfL5/2dddL9vJA0WXhc74rkNHVi3I9nBFFMHueEIw9JEf2BZB4S7wREE58izWl9fQPn0ZTlwxnDksARxDGaqhKWSlVZlslL9utwueRXvnsHJwiE7qjkxSJJKLYYEV2s3KcXeRDwZDIhSlNOJhMsXWfqupyMx4xXwju7blk82Ljkf3/rL3G+E9JJbf5W+lfoLRpEScK7jx4hyzL7gwFeGFaiQa2Udq/nMDRFodHp4AQBX9vdxQtDokuPzTubXNy9oGYYdGo1LF0nSlMavTpZkKLWdKy2JQR/qoz3YIla10UZOMswSqJh5ifIqiyM2ABzUCNxoivvEog3uIJHfFXii6w+/SM+Ox+AF+w8FkXxO8DvXPV7S5KEWhPlQ71hsJiNsW+0sZIMtWFg7zSEu+fYIw4S0iAlXUaCF+XF6G0Lu2OzCRi2jucEnJSg5fhTW/1ktSKZBUiSRJymVbVq/N4FM9fFKc3j1wrbMElIsowkTXn/+LjqLfzxvXsCdJBlHG6N+dE3TshUcbHMNZ//VPl9/oX8OyxGDludDl/f2xMzGOXup5aVJKXsRFslNmez1cIpexA7X9tBa5uEF47gwWoaG60WUTlwpLVNJDVGVmVqN9vIhkIwcgXvtpzEW5//bdNANlXR+Z8GpF5MPA3Qexay9mI+2r80x6efZwgAsIWsyhhdC/taA71pkpXGIv65g1rXKLKixNUkpG4JHgtTUiei++0d5A+GLM+WpHnOZquFoiiEcczZbFaNjS58nwePz6rmlxuGXM7n3Lp1DbtuEvoxx+NxNXMNgiiyHgvVFIUszwVWvyiIk4T/a+/DakGsI5Yzfm/wHr/GDa51u4xL+oZbNgwtXadumtRNk2vdLpauVzmMoWk8mU5ZeB6bvU41Ex1EETu/usvwR+diws5QsLa7JE7E6sMJakunfqtT7QjZM0NV68jCtLIJFh9naDXErPYV45eyJPtlh6xqGF2L4NKhyC3q+23ckwXBuTAzTJ0Yc7uGpEjESYL7YE6UiDcxvHTFkL8bo/ds6p5gRk2DgEeXl3hRVM0uHI1GLD2Px6MRQRyz1W4TlzMPeZLTfLOPfunSdF32X9vm/kfHgFDYJlmGXJZZ13a9Dy4vWUQRS+2z8TALzSfLcx5eXnIwGDBcLNgfDITJpGEIR1RdZ++NHRRbI7x0BY9JVSs74trNFqmbIE+flkzlsrCQRRl6y2Tx4YgwjDHSnOxaRhKmFHGObomcY7hc0jBNGpmJtV2n+UYf58FMFC8MoZx9kUT7l6Z59/OMosgE8HgVEc0C0iChfWeAJEtiAGkRMn4g6v9RmnI6nbHRbIoBolkAMixPl2yUnnZxqTK91utxMh4zc13a9TpJ2eN4PBySFQXd8jG5zCecj2fUrrdo12oUWVHhLQ/u7BBNAvSOyfxsga6quFHEm7f2ubyc0s1qzFTvx36uZmzxq7duMV2teOPaNd49POTGxgYHWxuoNY3FaIUsSagNnTzJab+ziaTK6E8s0Uy89MjTAnOzhtoQnth5JMSHqqZgX2uweH9IFghBYJgk1COB4ckUBUMR47b9RoPuHTHLobcMgguH8Nytjk6pG30C7fMT3yuodtCvSryciyLPqybU4u4Io2+T+DG1ay3yNEcxFWo5lRXXg4enT+19fXGMWvo+zQuX07MxB6/v0Je6LE4X1YBOnKYMmk3mm5u4Yci7h4fClKXEy6xLmFrLoP/1DeZ3BbzYDUNSL6H9zU3m379guFgwWi4xdZ3makWcpnxreJ0/vH2PRH56seiFym8m/yzfvnWLP/34Yyxdr0gcjy/ErPVGu4W110TvWCz+ciiMWo4WKKaC0W9ibtQwejZmaSxf5IJGruliNgIEmSMLxM0iToVcJU5TlDzH0FRyYOF5xB+mNEwT+6CFrCt4UUTyo0t0Q0Nt6SC/QEf7cyTakiQdAQ6QAWlRFN9+nq7uRb/2S7koANSahtG3cT6eIm8phOVAf3DuVEK6oijIQjFaGpcl2/UQ0dL32VpELH2fZBFxPp6y/9p2JYzLIzHVJkkCs39nZ4eiVKDmeS4ukjQlngSixNmz0ZwYWZax95qs3heaqfFqxSoIuJjPCdbd7NDgzcUW998aEtVSaqHBXxt+ne/at9BNRVyMuk7DNKucAmDheigzDbWuEzghtVVEMg9ZLQJ0Q0NrGyUZ3Mfo18TRqmMSTwNkQyTH8SxgMV4x9zxBH4nELIiiKMIBtfzZNppNrGsNklWE0beJk4T2TgutaaA2DFTrapfWP+ZO8VeLopg88/HziB4vFC/toiiyohx6EcNGSTlIv/avky2VzBfVIEmSSPO8YiPt9ft4YUgSC3ZSGMbMPI/2xYr+1zZxH4iK8KDVZGuri3VyyYOLCy7m80pwuDZYPLoYcpDltL+1RTIPsTLxepYLl73tAd16ndFyiaIoFWgtSlO+E7zGP/hf/4y/8s47vL69zSRcIddl7HLYyC7l62/t7aHYGmpNQ2sZmJt1nI+nhOsmmwS6odH+5mblYWFvN0icmMXdEe03N0hW5e9GE97YUmlUn6QpeSwQnGqZZOdFQbdWY+I4SPeEj19rKvA5mZ9CDmrDuDLipvjZap+ep6t7oXgpF0WRF6R+XLqVZuUUnoAFN+/0UW2NeBmh7jUpPpowni+Ze+IMn+U5Dy8uyErgmBuG5HmOW1aXvIdzDkcj5q6LZRhYmoYiy9ze2WFRfo26ZbHwPM5nM3a6XcI4EUb3UUY8DQgdYTjf2+sSzx1ee2OPxw/Oub29zXvHx5xOp1yWIIN5OQj0zZs3qW/WKZKc7VWHWr9GZ1pDrWkkbsyTsxFNy2IQDCpW7PLhjLnrsrXRJXEEgT0LUuJlhGIqJLOQYOhSP2jjXzhEswBZlSvah5plFLGYQ9ENgyfTaXUBr0kiaunlbepidypWBZIiUb/V+Yx35rPjMxLtq9A8CgQAvAD+i/Lzz9PVvVC8lIvi2TAGNtHQFY6lq4hw4qHYGtIqwnu8QNYV+o0GZnmHV8sS6Wi5JC8KhqWHnBMEHI/HZEWBres4QcD5fE7NMNhst3FLSXkQx6yCgK12m8fDYcmKFXdcxRSzzXqs4UURo+MJw9L/erxcEicJ+/0+13o9vv/gASfDIYqiYOo6miyzOBfDUbtbfZJ5yM2tTbSuxXQsQGyDZpPgzEEx1Wp0dffWFqknKIbRSBwhUzcmdSFd2xUkGasPxug9YZ6ZlXmRmmUsJw5ZnvO4VN72Gg1kWaZZt2nWbdSGLhZSmqO1DYLjFfZ+q3Kk/WlRlDTET8VVaB7/VFEU5+WF/weSJN27+lXxk+OlXBR5muOfrohnIckiRKlpIAlESxaWOPpIjJ+GTlh5xkmSxGi5rLy1g1g4H/3Fo0ekec6HT55USMu1VddkteLh5SV52YTb6nRomGbV3e7U67QHTcILl8VUSDvWuM1HwyFJmjJcLCoTxyTLaJgm/WaTNM9RS07s4/GYy/kc2zCwDYOaaYputNpElmWCWEz3HV+OaNk2l4sFLdum5tm0f2WTeOZDJgSJ2lLoqYI4pi5JBKcOXhghLWTMHUE0yfIcWZI4HA5xgoDXt7dFL8QyMbZq6B0LxRa/M9Gsk5BVhTzMyONUuBxdIT5v864oivPy75EkSX8f+C7P19W9ULyUi0KSJaxrTbSOSXjuMns8pak2yeMMWZWJpgHttzaISwfVeB5WJom9THhS1AxDyLifQWCCuLPFafqJu5ul69imyYOLCyHxAOKyg51kGScnQ27cvka/0cO6cKvZjjBJqmaYH8c0TJPD4ZDDz/C0Xvk+3Xqdm1tbmLaO2tAxehbBqdBmhXHM3eMnuGHIzHUxNU0MI80c9FML1VYrha9V0sijJCkpiQbJacrS8XA+FhZka/qhrqp0ajVRNSvLzQY1nI8mtL+5yfLeBMVWab+1wer+hMZrXWq7TbLoasnzc3aKn/z+SlINkMs5nRpCD/d3eL6u7oXipVwUeZKxfH8kDN+jhCzPGZ9OqVuWGEA6WaJaKtFUVIbab28wf1dQTzr9LvV5SN0JBFmjFNOtxzLzPMcv7/Rrwd3FfM7j4ZDJcsn+YCAkHyXZO89zZr6PfTRm52s7tF7vImkKWZgQDX3Uuka6ipEUifOL6ScQ/M/GWtJ+Np2iLhRats2GPuDoyZCGaVYTdZ16ndvb25V8pLvbQbXF2+xHkRitDUuPjTRFVmUUU6hp3VDsmtsdkQ8UwF6vh22bQuCnSJibNfJE2H3Zy4jlzKFFo8qX4p6FYmkv1NH+HDvFJvD3SyWzCvwPRVH8niRJ3+ezdXUvFC/lopBVmfprHVJXXGypn7J8MK086EInopbmJPOQLEhQLI3azTapJ+jktYMWxrlDFqRYlw6tG52SbyTyjmQREo19tI5JPAsq+6+Z4zyVcQ8GAucfRSw9j6lhYD6cMHhnm2QeoDYMZE1mfrpgVfps2yWULUrTagdZc5zCZ+Yv1pLw4Mxh5goiYZJlvH1wQL/RQG0KIxW9Y6L3LBY/HKI1DcIkESyoMERVFAZlZz6PUrSy6hWX37soCgFZ0DRqDQutbXB5f8hAlYnnIV4ofndBHNNRZVI3IvQiTDcmcSPy8GqLoiiT+heJoigOgV/5jMenfIau7kXjpVwUkiyXXgkZ/uMF3tzHDUPqpkkWZSJX8BLiZYg/joknAbWbbdSGweKHQyRVpnarLSpVj3SyMCU4E/lA07KQFRmtaTA8nXI6nVZwhP3BgOFyyaDZZOX7gkBeqmzD8jiVhQnJKiZPc8bnM05nMyxdZ+IIdmu7ViNee91lWcWZjdOUi/mcmevSrdfZaLXo1OssyzHSLM9ZeJ5gzo5zUSq1bXo7HaIogUVRNRazPMeSJDFjJQnM6HrmW9e0Cpy2zpsUWyP1E2auiz00uJjPidOUJ/fORV9HkXAfLcTP5ydVYn+VeNXR/pIiTzIWHwzRezb2jTayqRAex4K6HQpfiSLNicpjSu1Wh/DSRa0n+FFEFuTYaZPV/QlG3yb1E+ZHM1ZBIEzoVZXIcenYNqfTaXVUWeuLHl5e4oVhNebqR1EFP8gjYbsVuRGdep2FL/RMYRzzw8NDvNJFaR07nQ4fn58L4Jph8Nb+Prqqsr3b5/6DJ8IY8pm77VrxahsGm7c3Sd24krxnWcbK93nzQMxy6V0Tc7vB6sNxJZG3dJ33jo+ZuS7bnQ5Ny+L0aEhaOqTOXJdlCYyWJQkvinj8SLy+tU9ePAt4/oDlJ+OXasjo5xlFlpPMIyHsy/IKMZ8Xhbi7xTHnH51j6sLuNwsFZkYLUoIkIcsyYdwyDSq4QHOzWSWqbhiKru5Gm91eTxA/koT3jo4qQ8VBq8X5bEaYJFW1ae1Dt3L9Srl6+84+Fydjpo7Dd19/nYv5nD+9f59F+b3+j7/4C6wS6V83Tf4oiujW61wvAcpOEPAP796laVkEccwb165hdSxSJyYPU44PxdzEs2O0kiJxcjHmVncXgDTJqlzm44sLtktbgMlqxdx1hSRdllEVhShJKvpgd69LcBjTsCxauy2Gh2MW4xXaXKX9Wvdq7xW88PHpi46XdFEUyLpMFjxlIcVJQlbSMNbWXDvdrpidTjK8MERP1coIUZIkZF0hHHnMfR8vDNEUhVUQVBfjcDhn9842Fx9fsvQ8drpd2rVaddcFqjt/lucokkQRi1ntpecxdRza53P67WZlODlxHExd548//JAkivjrv/7r1AwDVVFwgoCaadKwLPb7/Woe47uvvy4ad60m4+UK3dCwDppcfChmOtaJe1reHNbmLMuzJdHIx2ybqFORr/Tqdd7c3eWsPNY1LYswSZAlibnncbCzURHFjY0azUub5m4Lo29hnxlYbYvMS1DMq03e8Uol++WErCvYBy2KAoyyJp86MZIsoV2Kys0HT55wNB6z0+lwfP8cVVFI4xhZEnLyhx8IuHHHFqAvpewFJCWicn3UGD8aV9IONwxZ+X41VHRjU8DQonJRrCfM1HJxrXzhsNrZbrPRbLIKAt7e38fSdU6GwkjxB4eHXOv1OOj3+caNG8IiuGZwMRK70LpnMvc8RqtV1ddQnRg3ilj5PqPlkjvXrlWg5XrJzY2ShFrDEm5Cz8g4ikIYQyqyzOViwY3Xd1Asje7Jktr1Fs79Ge1vbArax2ad1tc3yIIEq21h77cIL9wrv1drvdhXKV7KRaEYKq03BuRpThYkFAVkQUKyCvFnPhfzOaYmusrH43FFCVxT9vLy30VR0Gs0uL2zg1HyoIqi4HKxYLhYiHllx6FmGDQsi91ej3FJ8NZVlclqxfFkUqlq/SgS9ld5jleWPwHOjkd89OQJE8dh6XnMPQ9D07i+tcVfffttTE2jU6txPptRM01udLYrwmGaZbz76BGWYdCyLNq1GpeLBdcbJlmWCaPKsjyc5TmXiwVbCHuwWs3i4+Mzdns99BLwVjdN7p8LUv26u68fKkLIqOsM37/EjyKKHxYopop1rYHzYIqxYdO43aN+vU2R5WjNKwKWeZVofzkhiT/xotQrHS+rN6k2qFes2DVPaV0Zgqcm84NGg5PplPPZTCTm5ULJi4K6aRJnGQ/Oz3FK2oapaXRL5lKtZjGcPlUsy6XD6la7zXA8Z7hcMnMcwiThyWTCXr/P2wcHnE6nmJrGaLmsEP0fPRHIqzXR7+t7ewLIUL6eJMu4ubnJbq9HzTBo18WsxORizsRxhHarnOhbX3yWrtMcNLg4nTBaLmnZNnXTFM6xz+xmqqJgahrH47Ggjz8zB76GMBsLF0PTMM8ctLZBFiTU9lpXJom/2im+pMiTjOW9CclKMIoyP8E7StG7Fo3bXYq0wDh3hGI2zqAocM8dNFUhiMQCqNWE29DaZPHZHWThefTKgSK79JUAceFaus69k1ORpHoeRfn/4jRl6fvcemOX9mUNNwj4wePHzD2Pbr3O/uaAdq3Gu48efeJnqZlmddHsdJ8mr8/uFGszyTTPeXhxyUE6oF2vYc51NFXF1gV0wNA0ccxaLtGP1SpPAWGnrMgyK9/nmzduoMgypq5j1A38VYAiy4KIUgoABzvdisql2Bpa28TarKHWdOztJql3r7Oe0wAAB3VJREFUdXuvz2pW/jzjpVwUsqbQ/tqAxInJQkHpW/xwKKQcBaRejLVdxz9dMTmZ0d/v0vvGFnmUUpdlKAQjVZ0KQt7+YFAtjAJxQdZMk6IoMFSVP7p7FxCK1qjXo99sVoh7XVHENJyi0LQsTh5cVNbALdvmeDxmu9Phhw8P6TUadOp17p2dcTIe06rV+NbNm9QtC0NVuVgsCOIYL4qomaYgapQL4wePH7PZblMr8ZiSJFVykou5sAzWVZVeo8Fev8+Diwtsw8ANQ5a+z9FohKlpnCyX/NmDB9iGQb1M6pvlsaz3+gC1ptHyEvSuhd42KdIc2VAhL0jDhHixQqsLM03e/Onv1avq05cUWZjiHi8IL11SP6GIc2RTIVmJM/2a9k0hOsbtVYzriuOOu/CoN23MHaGBato2m23BcImSFKtm4Kx8piW3aV7qjIqiYLhc0plO2WyJEdS9POdiPmej1aJfJtKbrRarIKju0FGSYOo6Pzw8ZLvT4Vdv3ODcsirD+HcPD/n63h7Xul2Ox2NulYaN66R4fUFpJVShZdv4UYSuqtWC2e50uLGxgSRJSKVPxf2zM2RZRpYk/uTeverfhqYhSRJaeXSydJ2GZVHfbqCYCuP3Lmntt1m+P0LvmBgbQr7uHS0wt+qknmjexYvwM96ZH481MvSrFC/lokCWBGWiJiy2MjkhWUbklCaRS9HDWPlCQiFpMu5MzEKcz+dsA+7KZ+PWgPa0jrPyK7L42XTK/mBQfSutFM/94PBQyD12diqjxXVZ9s/v3+dysWCn0+HtgwN6jYb4WrMZUZJwNp0yWi45GAx4eHlZfe08z6sj08x1GS0WbLfbfPTkCW9cuyYYT+X8+Os7OwCMl0JebhsG/UaDh7LM4eUlx6NRdeHLsowiSfyTd+4gyzJ+JI46kiRhqCr9ZhO7HHc1BrZA2ZSWZ0vfxxobhGGMZdWFQWSYkswjtKYhmqNjl8S5mrn855F5fNHxUi6KNdrGP3ME7zTNKWIhw568d4nVMCkSIfAL4pgHj06xdL06Yx8MBjwejWgOGrhOwML3Ucvz9mi5pGaa9BoN9jcHnI6nfFRKyserFV4YcjQa8dr2Nte63eq8/I3r12nVagwXC45GI7Y6Hd4/PiZKEv7k3j2CUJg3fvjkCb9+5w7bnQ4Tx+HtgwPk0l5r7nmoisJfHh0RJglns1nloX1ZYvjT0n3pqHQtUmWZN3d32el2KwTneoQ2zXOu93rULZMwFr0Iv+yruGHI+XzOXtbHCQKUchdZL6D6oE7qJlVzMwgi9NLnzjtcPJ/49anIi4IwvtoC+rLiF2ZRSJL0PYSpiwL8V0VR/PbznpsnGdE8FHwjCdJlxMV8XsHG8kk5E1EeQfKSUvf44oI0y3DLY5EzEZUVQ1Wrqbq1Fa9SIivDJGGz3Wbp+xxeXnLv7IzJaiWadqUtMMD983PR50hT8qLg0VCoW/f6ffKi4E/ff58fHR1xNpnwa6MR/8nREb0oYvLhh/x329v8o16PyWLBu48eVTlJw7J4++CA+2dnNCwLqRQMypLE0WiEJEmYZSd/4Xm8trX1Y7vF0vc5nkzwwxC5XPjrDrYiyyw8D0WWkcuOtiJJPDg9rzrcawibpijEhxN0VaV9o4tiXJE6nucE0dWS8i8rfiEWhSRJCvCfAX8NAVz+fmnc8tFnPb/IC/Lw6V1MsVQ2Wy28Ujq9riLlpZ5np9tFkSQ2Wy0+ODnhB48fk+U57x0fV8msqig8KMdUx+VU3nqRrf2tN9vtqqm3LO20AHZLvOU6ZEnCC8PqsSzPub67S5Qk/A3gX3nwAKPs8g7imH/z5IQC+IfdLm4Y0q7V8ErYsSxJREmCLMvVHXd94YOQm9w9PUVTFOblBa4+c9EDOKWr0fo49rW9PeaumL9eM668KEKVZdwo4mB3E1mV8ediB5UV+RnrL4Uiy5GUq11ar3KKzx/fBR6WkmFKCPNvAJ+5KGRNQe/Z5GlBPPHR2ibmdh1t6KGVFZMiyynSAu1iQWOvxeJ4zsLzqJlmZb2rKko1kxwlCW/t71de159u+GV5LjwlygbfGm+/BjIDlRz8WaTLs4+1azV+83d/t1oQ6zCLgn9tPCb87neri31NRZclidFqxe3tbZwgqJLp9eeyPKdpWSw/tQM8+2dNA3ljf5dHZxe0WjWatvWJ19AcCNSofrlEkkBtGbR6JrIiI2kKsiohqcIbT1KfUtt/WuRZhlPOo39VQvo0BvGrGJIk/YvA94qi+DfKj/8m8E8URfFbzzynMm0B7gD3v/QX+jOIb8G3nve5d+HdL/O1/IzioCiKwfM+KUnS7wH9Tz08KYrie1/sy3p+/KLsFD/VuOVZ05ZX8YsTP8+L/3lxRYzbzz2eZ+jyKl7Fzzx+URbF94HXJUm6IUmSDvzLiCH1V/EqfubxC3F8KooilSTpt4DfR5Rkf6coig9/zi/rVbyk8QuRaL+KV/Flxi/K8elVvIovLV4tilfxKj4VrxbFq3gVn4pXi+JVvIpPxatF8Spexafi1aJ4Fa/iU/FqUbyKV/Gp+P8BK5BktaeKahgAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "## Plot Square\n",
-    "%matplotlib inline \n",
-    "map_fig = plt.figure('DEM maps')\n",
-    "ax1 = map_fig.add_subplot(221)\n",
-    "ax1.xaxis.set_visible(False)\n",
-    "imshow_grid(rmg_sq, z_sq,plot_name='Square', color_for_closed=\"white\")  # plot the DEM\n",
-    "plt.plot(rmg_sq.node_x[outlet_node_to_sample_sq],rmg_sq.node_y[outlet_node_to_sample_sq],'ro')\n",
-    "plt.plot(rmg_sq.node_x[midstream_node_to_sample_sq],rmg_sq.node_y[midstream_node_to_sample_sq],'go')\n",
-    "plt.plot(rmg_sq.node_x[upstream_node_to_sample_sq],rmg_sq.node_y[upstream_node_to_sample_sq],'bo')\n",
+    "# Plot Square Basin\n",
     "\n",
+    "# set up the figure\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(6, 6))\n",
+    "ax.xaxis.set_visible(False)\n",
     "\n",
-    "#KRB note: I'd add a legend and make the plot bigger. "
+    "# plot the DEM\n",
+    "imshow_grid(rmg_sq, z_sq, plot_name='Square', color_for_closed=\"white\", colorbar_label='Elevation (m)')\n",
+    "\n",
+    "# plot the sample nodes\n",
+    "ax.plot(rmg_sq.node_x[outlet_node_to_sample_sq], rmg_sq.node_y[outlet_node_to_sample_sq], 'ro', label='outlet')\n",
+    "ax.plot(rmg_sq.node_x[midstream_node_to_sample_sq], rmg_sq.node_y[midstream_node_to_sample_sq], 'go', label='midstream')\n",
+    "ax.plot(rmg_sq.node_x[upstream_node_to_sample_sq], rmg_sq.node_y[upstream_node_to_sample_sq], 'bo', label='upstream')\n",
+    "\n",
+    "_ = ax.legend()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "** 3.3.2 Spring Creek: set thresholds and select the output nodes listed by threshold **\n",
+    "#### 3.3.2 Spring Creek: set thresholds and select the output nodes listed by threshold\n",
     "\n",
     "We will identify the nodes for outlet, midstream, and upstream locations for plotting hydrographs using drainge area thresholds for the latter two. Code is written to set the outlet at the node with the largest drainage area. Below we will first identify the outlet node ID, its elevation and drainage area.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outlet Node = 55472; Drainage Area= 26.7525 km2; Elev = 1875.3 m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "outlet_node_to_sample_sc = np.argmax(rmg_sc.at_node['drainage_area'])\n",
-    "print('Outlet Node = ' + str(outlet_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[outlet_node_to_sample_sc]/1000000) + ' km2; Elev = '+ str(round(z_sc[outlet_node_to_sample_sc],1)) + ' m')"
+    "print('Outlet Node = ' + str(outlet_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[outlet_node_to_sample_sc] / 1000000) + ' km^2; Elev = '+ str(round(z_sc[outlet_node_to_sample_sc], 1)) + ' m')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The midstream and upstream node drainge area thresholds can be identified by drainge area ranges in km2. The range used to identify a midstream location should be larger than the range used to identify an upstream location. These internal nodes can be identified by trial using different drainge area values, and plotting the locations selected. After we select the drainage area ranges we will print the node IDs, drainge areas, and elevations of the locations we select and map the locations on the elevation map of the watershed. "
+    "The midstream and upstream node drainge area thresholds can be identified by drainge area ranges in km$^2$. The range used to identify a midstream location should be larger than the range used to identify an upstream location. These internal nodes can be identified by trial using different drainge area values, and plotting the locations selected. After we select the drainage area ranges we will print the node IDs, drainge areas, and elevations of the locations we select and map the locations on the elevation map of the watershed. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Outlet Node = 55472; Drainage Area= 26.7525 km2; Elev = 1875.3 m\n",
-      "Midstream Node = 47742; Drainage Area= 18.7497 km2; Elev = 2062.2 m\n",
-      "Upstream Node = 19131; Drainage Area= 3.2094 km2; Elev = 2243.2 m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "## These values can be change to set drainage area thresholds in km2\n",
-    "midstream_da_upperbound=20\n",
-    "midstream_da_lowerbound=17.5\n",
-    "upstream_da_upperbound=5\n",
-    "upstream_da_lowerbound=3.2\n",
+    "# These values can be change to set drainage area thresholds in km^2\n",
+    "midstream_da_upperbound = 20\n",
+    "midstream_da_lowerbound = 17.5\n",
+    "upstream_da_upperbound = 5\n",
+    "upstream_da_lowerbound = 3.2\n",
     "\n",
+    "# Identify sample nodes.\n",
     "outlet_node_to_sample_sc = np.argmax(rmg_sc.at_node['drainage_area'])\n",
-    "midstream_node_to_sample_sc = np.where(np.logical_and(rmg_sc.at_node['drainage_area']>midstream_da_lowerbound*1000000, rmg_sc.at_node['drainage_area']<midstream_da_upperbound*1000000))[0][0]\n",
-    "upstream_node_to_sample_sc = np.where(np.logical_and(rmg_sc.at_node['drainage_area']>upstream_da_lowerbound*1000000, rmg_sc.at_node['drainage_area']<upstream_da_upperbound*1000000))[0][0]\n",
+    "midstream_node_to_sample_sc = np.where(np.logical_and(rmg_sc.at_node['drainage_area'] > midstream_da_lowerbound * 1000000, rmg_sc.at_node['drainage_area']<midstream_da_upperbound*1000000))[0][0]\n",
+    "upstream_node_to_sample_sc = np.where(np.logical_and(rmg_sc.at_node['drainage_area'] > upstream_da_lowerbound*1000000, rmg_sc.at_node['drainage_area']<upstream_da_upperbound*1000000))[0][0]\n",
     "\n",
-    "print('Outlet Node = ' + str(outlet_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[outlet_node_to_sample_sc]/1000000) + ' km2; Elev = '+ str(round(z_sc[outlet_node_to_sample_sc],1)) + ' m')\n",
-    "print('Midstream Node = ' + str(midstream_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[midstream_node_to_sample_sc]/1000000) + ' km2; Elev = '+ str(round(z_sc[midstream_node_to_sample_sc],1)) + ' m')\n",
-    "print('Upstream Node = ' + str(upstream_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[upstream_node_to_sample_sc]/1000000) + ' km2; Elev = '+ str(round(z_sc[upstream_node_to_sample_sc],1)) + ' m')"
+    "print('Outlet Node = ' + str(outlet_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[outlet_node_to_sample_sc] / 1000000) + ' km^2; Elev = '+ str(round(z_sc[outlet_node_to_sample_sc], 1)) + ' m')\n",
+    "print('Midstream Node = ' + str(midstream_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[midstream_node_to_sample_sc] / 1000000) + ' km^2; Elev = '+ str(round(z_sc[midstream_node_to_sample_sc], 1)) + ' m')\n",
+    "print('Upstream Node = ' + str(upstream_node_to_sample_sc) + '; Drainage Area= ' + str(da_sc[upstream_node_to_sample_sc] / 1000000) + ' km^2; Elev = '+ str(round(z_sc[upstream_node_to_sample_sc], 1)) + ' m')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7fde4f56b450>]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWkAAAEWCAYAAACkD2ZaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzsvXucJWdV7/1dVbWra3p2J53JxEy4hCAJInh4vcQrHo9XBFRyvL4ih4uieAEhL4hcwhFEgng54SbqCYYjHFHkCGhQvAReOUcEkSQit4BECDFgSIZJJ727u3rvqnrOH8+znlpV3Z2ZZHqmu2fq9/nsT/euXfVU7T09v1r7t9b6LXHOMWDAgAEDdieSnb6AAQMGDBiwNQaSHjBgwIBdjIGkBwwYMGAXYyDpAQMGDNjFGEh6wIABA3YxBpIeMGDAgF2MgaQHbDtE5C9F5Ek7fR3HCxG5QESciGQ7fS0DTl8MJD0AEflmEXmfiNwpIkdE5O9F5Gvv7XrOuUc7596wndeoEJEzROSVInKziExE5Mbw/OCJON+AATuNgaRPc4jIGcCfA68BDgD3BX4ZWL8Xa4mInLC/KRHJgXcDDwMeBZwBfBPwReDrNtl/iIAH7HkMJD3gwQDOuT9yztXOuTXn3N845z4MICJPDpH1a0Kk/QkR+Q49WETeIyKXi8jfA6vAl4ZtP2mOf6+I/KaI3CEinxGRR5vjHygi/0dElkXkXSLyWhH5gy2u9YnA+cD3O+c+7pxrnHO3Oed+xTn3zrDeTSLyXBH5MLAiIpmI3EdE3ioit4fzP8OcPxGR54nIv4rIF0XkLSJyYLOTi8gPhvW/4ng+8AED7gkGkh7wL0AtIm8QkUeLyFmb7PP1wKeBg8CLgLf1iOwJwFOBBeCzWxz/yXD8rwNXiYiE1/4Q+EfgbODFYa2t8J3AXznnJkd5T48DvgdYBBrgHcA/478lfAdwqYh8d9j3GcB/Bv4TcB/gDuC1/QVF5MeBXwO+0zn30aOcf8CAbcNA0qc5nHN3Ad8MOOB1wO0icrWInGt2uw14pXNu5pz7Yzzhfo95/fedcx9zzlXOudkmp/msc+51zrkaeANwHnCuiJwPfC3wS865qXPuvcDVd3O5ZwP/fgxv69XOuX9zzq2F9c9xzr0knOPT4X3+aNj3p4HLnHO3OOfW8TeKH+pJJZcCzwG+1Tl34zGcf8CAbcOg2Q3AOXcD8GQAEXkI8AfAK/ERKcDnXNeJ67P4qFPxb0c5xa3mXKshiB7jI+sjzrnV3lr332KdL+IJ/miw1/MA4D4ismS2pcDfmdffLiKNeb0G7E3qOcBLnHO3HMO5BwzYVgyR9IAOnHOfAH4fsLrrfY08AV4X/rw97F6e7t+BAyIyb7ZtRdAA7wK+W0T2H2Vdez3/BnzGObdoHgvOuceY1x/de71wzn3OrPFI4IUi8oPH+L4GDNg2DCR9mkNEHiIizxaR+4Xn98dH0P9gdvsS4BkiMhKRHwa+HHjn8Z7bOfdZ4FrgxSKSi8g3At93N4f8TzypvjVcdyIiZ4vIC0TkMVsc84/AXSGZuE9EUhH5ClNi+LvA5SLyAAAROUdELumt8TF8NclrReSx9/LtDhhwrzCQ9IBlfGLvAyKygifnjwLPNvt8ALgIOAxcDvyQc+6L23T+xwPfiJcyXgr8MVuU/wXN+DuBTwDXAHfhSfhguMbNjqnxxP+VwGfCe/g94Mywy6vwOvjfiMgy/v1//Sbr/DPwvcDrbHXKgAEnGjKY/g+4O4jIk4GfdM5980k63x8Dn3DOvehknG/AgN2OIZIesKMQka8VkQcF6eJRwCXAn+70dQ0YsFswVHcM2GkcAt6GL6+7BfhZ59w/7ewlDRiwezDIHQMGDBiwizHIHQMGDBiwi3FKyh0HDx50F1xwwU5fxoABA4DrrrvusHPunONZ41GPepQ7fPjwsZzrr51zjzqec+02nJIkfcEFF3Dttdfu9GUMGDAAEJHN/FzuEQ4fPnxM/6dPRcvaQe4YMGDAnkBT10d9HA0icn8R+VsRuUFEPiYizzSv/byIfDJs/3Wz/fnBt/yTxpgLEXlU2HajiDxv299wwCkZSQ8YMODUgnOOaraZd9c9RgU82zl3vYgsANeJyDV4r5ZLgIc759ZF5EsAROSheDOuh+H9at4lIg8Oa70W+C58VdIHReRq59zHt+MiLQaSHjBgwO6HczTN0SPloy/j/p3gpOicWxaRG/AWtj8FvDx0teKcuy0ccgnw5rD9MyJyI+2AiRuDqyIi8uaw77aT9CB3DBgwYNfDAU3dHPUBHBSRa83jqVutKSIXAF+FtxR4MPAfReQDIvK/jbfLfem6Kt4Stm21fdsxRNIDBgzY/Tj2SPqwc+7io+0kImPgrcClzrm7gn/4WcA34D3I3yIiXwrIJoc7Ng9wT0jTyUDSAwYM2PVwzh1TYvBYICIjPEG/yTn3trD5FuBtwTf9H4O/+MGw3drn3o/Wpner7duKgaQH7CncVf8OAJVzVEDZNJyfP31nL2rASUHTNEff6SgIvuhXATc4564wL/0p8O3Ae0JiMMc7Jl4N/KGIXIFPHF6Ed14U4CIReSDwOXxy8ceO+wI3wUDSA3Y9Gq4EPCEDlM5RNo0nauf4l/LVPLh4xt0tMWCPwzlHNZ1ux1KPwM/R/IiIfChsewHweuD1IvJRYAo8KUTVHxORt+ATghXwtGB/i4g8Hfhr/KSf1zvnPrYdF9jHQNIDdjXq6ndJUsGJUDnHUl1Hsq7CPhnw6fXXUDlH6RwP3/fMLdcbsEfh3LZE0mGO5mY6M8B/2eKYy/E+6v3t72Qbhl8cDUN1x4Bdi7WJH9rtZOP/qQoveZRNwyQ8yhBZX7/6ypN8pQNONHx1x/E3s+xFDJH0gF2LataQpMIoS6icIxNhnPi4YmLkDiC+rs8/vPYqgCGqPlWwTXXSexEDSQ/YMdz+uVfQNE7rWwGYljVN48hGCWccKOJ2jZizEFVnQCbS2a5EDUTp4/9MrqAQia9rwhHgW8bPOllvdcBxwrF91R17DYPcMWBH8O83/SZN40gSIUkTslEKQJIKSSJkoyS81pJr2TQsVVWUNyZ1HWWPPjTSLo0MAsTfK+f4/5f/28l8ywOOB6Et/GiPUxFDJD1gR9DUDmjI50aAJ+f4WuJI0oS88MQ9Asap//3WqoqVHWVP7tBHkSR+H6AI0TZJQmb2A2LUPWD3wzlO20h6IOkBJx2f+fjLfaQciFl/Kik3qY+wp2UdI+pRKozTlKKuIZDwOEkonWOpqigNWUObWFRpQ0ldI2sg6tsD9gK2p7pjL2Ig6QEnFR9530sYL+YAJGlLktmo/d1H2UH6CA8nAiFKruq6ExErtDRvoiV6zlEC4xAx22SjTTIO2P0YIukBA46C1z73yTzt137/Xh9/w7UvBSDLE/K5lCxPYzSdjZLO70rSc+MRolpy01A2DYUIRZZRJAmHgz5tdWaNngsRSufiH7ju04+k37b06xSBsG2TzE8cfMG9fq8DTgRO3+qOE/Z9T0S+TEQ+ZB53icilInJARK4RkU+Fn2eF/UVEXh0MtD8sIl9t1npS2P9TIvKkE3XNAzbH6170lE6ke09xw7UvJUmEfC4ln0sjGSdJqwnbhGGW+wfAmnPMaGWMpbqOkXKs9OhVdHRK86DTnWg17InRtsseyV95+GX3+v0eC37gX597TPvJ+37phF7HnoE7Zhe8Uw4njKSdc590zn2lc+4rga8BVoG3A88D3u2cuwh4d3gO8Gh8X/xFwFOB3wEQkQPAi4Cvx/u4vkiJfcDJQZL46ourfvmn7tXxTe2oZoFYRwlJmlDNmlB+1z5U2khDlA2h9C7IG+VmRA2xxE5hfT2UoCfmGMA/N7KJ7mfx+sMv21ayfuSnnsM3feJZfPu//EJ8L30c+NDPAZBc99PIPz4Lkqn/eZrDm/5Pj/o4FXGy5I7vAP7VOfdZEbkE+Naw/Q3Ae4Dn4g2z3xj65f9BRBZF5Lyw7zXOuSMAYYrCo4A/OknXflrjDS/76TahV987DXda1uRFStN4si5XZv55Ip1oGojt31YzVkLTmmgl1UyEIknIwu+ZCBkbI+cOgZtzlSGatrAVINtZ/fHYG3/Rrx+qTcqm4Vs++ezY5l6aKH7+n362PbAaR6J2X3fF5otvAXnPKyE/gvuml3S2P/JTz+FvLvqN431LJxVuSByecPwoLameG6Yj4Jz7dx1Tw3Gaawdz76cCnH/++dt68acj/vhVT+uQcjZKfC3cvUA1q2OU3NQukj6wocID2CBNgI98leAgELdzMYouRKiShDLspzXU0CYUO80u4bWlqvJErw0ver5wTCHC6w+/7Jg06pfd+pIYsVtZpdTz9m4KlUb6vXXKpsG5kSfo6QHIJgDHRNTy3pdCMvXHNTlUY+b/6Wc5mGUczDIW05RMhK++4f/j+i9/xVHf067BkDg8cRCRHHgs8Pyj7brJNnc327sbnLsSvF3axRdffNqm7a9583O8fBClBC8rAFzyU6/asP87rrqUJPVJu2pax+OyUUIyJz2ZQvijK36Oxz3rt+/RNTWNY1pWTEtPR9Usi3IH4JtWEgmSBzGKnhi5onSOsq5ZChIFtDq1jXhjJAxRzsiMHFKEsjuVQBazLJI4dE2bDhsCf/3hl3XWtPva9aynCNCp5dYbijbkQPfbQSbCbLroybkae5JdPwDlIZAp7LvVa9T5EdzFvwW08kg8T/IlnqCrsT8uP0K5/1/j5zapa4okYamu+ZJ/flr8jJuv+e/36N/05OP07Tg8GZH0o4HrnXNfCM+/ICLnhSj6PEBniW1lrn0LrTyi299zQq94j+Ctv/3zpjOvrY7Qn9P1Gp92OLaviXmRReIEqKa+TrlDpqnwml94EtP1mme/5g+Oad2mdlRTfw1JKhTztqIj3CD0ZkBClnkiteSKkUCUhCNZmrbwGAkbMi2dI9vE40N1a43QN5M3lEQPZllbwqefj+1kDBGxShm2bltvOKqDaxXJHVUCJDA9CNWYWTL1xFwegjqHOkTSydRH09MD7b/V9T/TRv/mphChkfT0AG79XJbzI1Spj/LHSRKvx0fsZyLvfSnum194TP+eOwHntsdPei/iZFTzP46ufnw1oBUaTwL+zGx/Yqjy+AbgziCL/DXwSBE5KyQMHxm2nfbo67m6TZNuWkmh9cjvuOpS3nHVpXHfP3udNx/SrHg2SmIFhj/WE6ityJgfjzhwaJ58LuVXf+pxx3Sd3/joy32E3vjkYJZ7gq5mTYiwa6Zl7fXq1QpXNVFfzoycAT4SLpLEl+KZ+mfVdvtSiUaYSyEKt1ankVA1uRh+78gVYb+bptOObNJ/6HZ7Tns91q1PiZryEKye73+Wh2D5Qphc6Lethe3rB1rCNftH8g/vx83Owq2ZGEdCEs0ct7Z+JpPwGSxXCW793Pbc5SHknW/zjz99zzH9u55MONcMicMTARGZx488/2mz+eX4+WFPAW4GfjhsfyfwGOBGfCXIjwM4546IyK8AHwz7vUSTiKc7YtlansYoF1ryVtmioiFJ06gxW6JW/wy7nka2MdqNpXFeS87nUhbP2QfAq571RMZnzrF4TsEP/txrtrzWatbELsLV5WnsJizmMy91BFOlbJT413JHlkqULzRJOO4RYWZIz0a6KmtkSqSasDNJQY2e++3ilXOQpm0C0b6P3n5bNcT0I357XtWnyY/ExCAAtSHk9QPgcv+7m7ZRdJODTHHr5zLLJv543R7kDQDSKax7TZrV8yH1+7p5WMsmft+pkVKgcw75k2txP3TUUYEnFadqid3RcEJJ2jm3Cpzd2/ZFfLVHf18HPG2LdV6Pn5wwwMCTcEvQSSLkRRpJ18sdRKKtZk2UFYBIjroWtESdz3lCLmajuEY2SihXqxgRq0ud1jS/46pLyfKURz9ho3GRknTSCHcdWSdJ/PHZKGF1MiMb1SSJUOwfxesqFkbQNGRJ4iWGuqZKvG1pFQi5SBLv61HXVFoZAvEr/YbrcI6lTbar30cR1rdRc+m/a7ekbipPJuEYu74lbvt7ERKbum3faI0yXfGSQzbxj9EEZoG4VZdeOd//VDLnEKxOPCFb8tbfVR5REp8egGTsiXt6oH1oFK3r6g1j5olf/ugTuMc9ZMNntSNwp28zy9BxuEehejTQ0ZEVKlNM1+s2wm6EPE1p6iR6NVtyViJVQtbuQN1P11LZo9jvCTyfS+N6AH/9pl/gux//m53rKVdah7Lpeh1vGpM7g/tdIhT7M/K5jGJ/xvjMnDOA/fMZdZrE6g6FtSnVhJ1KIdBWbSjZjk1kbRtXbgnOaRpR6/E28gUodX3zmpUy7HXZ5hr9fTFNmdQ14yRhcW6u0/3o38uEpbk7WatvbslZ5Y2V82ElFDRlh2AuRODZpN1Ppj7yXr7Qv66vaRKxuNUfP7mwrf7QBKXeFNJpe1wg6t0CNf0/HTGQ9B7E23/3GUbSaICkWyFh5ItiPmsJ1nb4NdLRr6HVs61nBhD146ZxFPMZ1bT2LnVzaSynm1/whD25c0rTON5x1aV831PaCSnVrImRvUopR76wGiP/+YU8VpYo5hdyqlnDKMs2JOtshKoOeZE0ndsQGdtmmAJPulb2iIRqEoi6bRLa0cumicepjKG6+FZ+1vqaXuc4yCiZiK8ecW2LeibCktRM5A6vF2tkO5rA9Ezy1VWm8/PgTPSrEff0gCfqJJC1kraScDb2yUhoI+pZuBlU+yDNoTGabj2GOkV+z3/y7id3mCrcUCc9YA9BI9vNEofQRtZ54aNg1X+bpO38sxJJxyZUiXLkOw2TpK3sUEJXScJWkzS181JIINmmcfyv1zydH/55Xyo2udMTgJYHTkt/07jryLqXTtZrivlRR44pV6sQ1TcspilL+Gh2EiIq1XaVKFXuoGmogoYdqzigI1MoNHrWBCJJ0lmzNHJGbEQxN4osTeO+QCcxqPvoNUddPay3mKYsmW8IB/WGkSSsJUYnTqaQ1khdM7e8TD0aUaWBlOeOwOgIrJ1DVgpVcaYnXoXLSWZC44IuDZ70AeoxadkgdYlLU+oiRNAuhzolnc2QssalbV37TuF0jqQHr8Y9Bq3I0KoNa1QUt9uIOUkioccouUfMqkErCXfWSiW2hWcj7/E8Px51vDeiYb+RSvT3N/2m7557wnN/N1ZwVLOaaVmxOpmyujzlyBdWufmTSxz+/AqryzMmd05ZnUwpV2ZRA4/VHhCrPXScVmxG0ddMc4olxiL8rs81eoWWwJWsJ6bJRNfR7fGnSSBa8tZ9tH19ScvutOIjrKuVJhNDPrauWptYYnIQSGcz8tVVH+nODvgEI0C2RtI05KurZBMhXctI1zKylRlZWZIvr5OuzPvjDNKZfz2dzUhm4gkayMoyPtLZjOy3drhywm2P6b+I3F9E/lZEbhCRj4nIM8P2F4vI54zX0GPMMc8PnkKfFJHvNtsfFbbdKCLP2+x824Ehkt6jUKJVzThuU+LM22kncPToW49v10niz7xITYQcdOuQLNTEZTbyunSe+vbvYv/IV3JMZvyPlz6VH3/hlUzXq+jTAV6b9mV4NaO84PC/r5h1k5joLFcqxqOWUMET56Lqz4HkbJScAQTi1Yg6E+lo0nYUlxKuShtxvU3Mm+zxlfN2qEAk25h81BK5kMwskqSN9sN1H64qlqsEkdInEKcHu1oy+N/rlKooPJlOp6RlQ12fE97sBOaOUBXnMX/bbT4qHo2oiiJG3kD8qXqzj6Jr0tmMdDajSRIg2Mg2DaOVFZKmYWqP3SE4t23NLBXwbOfc9SKyAFwXrCYAXuGc6yRTROSh+I7phwH3Ad4lIg8OL78WX712C/BBEbnaOffx7bhIi4GkTxFYu08bKWejJOi9TSdZqL+rNaiVLqCNoovcl8hVNCSN0DS+6cXKHEkqlKuzjpHSXUc8dSkpv/a5T2Zyp4+OJUkY5b5JRmTEwlmLAKzcdcTPOKybGHVPy8onQMuahSJlaROj/sM6rSU8txFvRdvibSNrrRe22jX4xhit2NDyvaXKr6zat64/ThIvwfSIfCkkCAsRCJUnN02nGwbpTuoaNzsLVs/HrZ7fiZhjx2DTRrb56irJdEpWlswtL/vdiv3Uo0VcmsbX8tVVqqKgKgpGKytURcFs//4QGQMkYf+VGCkrWVdFgaicVHoZJJ3NYGWF0atqZs/cd2//RI8P21TdEXov1JZiWURuYBObCYNLgDc759aBz4jIjXijN4AbnXOfBhCRN4d9B5Ie0EUsoUscTaK1xu28QAuNtCsaMqN0ZXmyQQKJr2licaaySBbX1tZxW12ia8wv5J5gizRGxNWsYW7fPMX+/UzLkulkmTRLmJYlZxw4m/W1JcZn5uRFFgcDxPdZu2i+1Dfv788x7CcWrZxgW8mVoGPdMu1/iKoXNesxfYkjE2FionKgU+1h9em1OqVMqhiBx+Rgk7fRsyb3ZiGxV+0jMeslTUM6mzFaWUHqmmQ6xaUpLk0j0er2DC9nuDTFlSXJdErSNJ6IVeII25LplAoYmc8qK0uaPPdRdIik5feqHUki3gNN+qCIXGueXxksIzZARC4Avgr4APAI4Oki8kTgWny0fQeewP/BHGa9g/qeQl9/LBd4TzGQ9B6HTdRFwm6aVq5IhYyEauZzYk3jCbpJu63eiiRJOll0+3o1azY44SWpdBKVei15kVKuViTJOuVKFY/dt79gfOYi1fyMJE2ZliXrayvcdssK97/oTOYXcuYXRhTzI4r5jLzI4prSI+JS66VpSTOOzdKEYb/e2WwrAsH25Q8dKKDVHmVIJFovESBOKbe11Xruw1UVBw/Em0R5iFky9U0oTe7L64IJUqzWWD3f/16PSWaC1LNOtKsPjaSVYJvck7vUtSfwosCFYzKIZK4ErsclTRMj56RpaJIkJgrT2Ywmz/2+4ZGWO1RhcezVHYedc0ftwhGRMfBW4FLn3F0i8jvAr+DvB78C/DfgJ9jaO2izfN4J8QwaSHqPoS2va5NzRz0m9U0k1axunxupQolZI3D9v2C17nwu3bIhxiYQ88JLE0kqkaizPGF8pi+ny4uCYn5/mBA+4rZb/o1iPmPxnIID5+5jfKYn6bxImV/ITfLSX28R5hoqOu3ZdKPo/mubDbDtr2Wj6qWqihLHxLUOdp0ywOAqZzVoJfPSyCCzan5jV6A2lajMUeck0zmaxEsKybSMUXNWlh1iLZaW/CE9rVjqOpK6QvVp3aYyRlaWkaABmjyPJN0h9DDEt0X3W87JwnZVd4jICE/Qb3LOvQ3AeAshIq8D/jw83cpTiLvZvq0YSHoP4S9+35u/2zbwftKwlR4amsYn+DRhmPT0XH3qk3SttGHbyoG2ZRuve2s5na3H1p/FfEYx7/+sJndOY+s3eF/ppdtv5z4PfBDl6gpNXTNbL9l/xj7u88AzfQPLgSI0taTML4w6OrtkCdV6Kz1Ybw9NCsZEH8ZXmu78Q9WUoRt121Fb+rNSfdZ8brpv/6agCUird+s5Ihlrp186aTXn8lDb5VfXzK2sRJLUCot8dTVKHOCJVyszpK6jJBJJ15B0Opsxt7wcdeuqKDrRMkATbtQ2kgbi7y5IIz65uJ+TDReqO44XIiLAVcANzrkrzPbz1EIZ+H7go+H3q4E/FJEr8InDi4B/xEfYF4nIA4HP4ZOLP3bcF7gJBpLeY9CSOzVDgrZyQ6HRMXT9O/I07exry/WUaPtyhraAQ0vittNRbxTzC3lcZ34hp6mb0MVYMz8ecdcd68Hzo+KGa98Xo/gD585zxoEiatxa4nfGgYJiPqNOhTvqmso1VNOqNVJio7m/LZnrN5ZAN2oGon2natoqSxwajaIUMgkVGODrmnWdQqSNskOts52t6Or9rK2YphMl58mFHTc7ykPky+tRT06mX4wJQpUilHhn+/d3It2sLKlHow6huzQlv+uuSK4xsjYyx9zycofYFVXh2/yb8Lfj0pTZ/v0xEo9JxB3ANlZ3PAJ4AvAREflQ2PYC4HEi8pV4yeImgt+Qc+5jIvIWfEKwAp7mnKsBROTpeLO3FHi9c+5j23GBfQwkvYfgia/bWLBZsq8PW4kRbUfNnMGmcUG3NjKGJe0Rba11nnasRZVsNVqOVSZzvmxvfiGPN4wkEYr5iqY+M9RBV74FfDH3Efj+Nilpk5GbRa19grbNI9bZzh5n5Q7wpFs5R2naxyd1za2zGYdGo1hHnYlEBz29ARRB5lBdOuudp9PanRjPjDqYJ1Ve0sjKMv60VRuKejTCBYLsR7lKpkquStaz/fvjfsl0SjqbMTOatSYMgY6EkpUlTZJEsbXJc+oQPeuNYqdIGtiu6o73srnO/M67OeZy4PJNtr/z7o7bLgwkvYegOnTHtc52C6o8UTu8h3Q7TUUnq1Szhmldt12FvdbvPulrC3c/gVhN/b7T9ZpiPott4dbwKcvT2JauOmYZ/Km9Tt06380vjMjnMvIi7ejsdiyWrcjQZN3EyhGmBln3s5UZSrqLRj/WKNk67Nna5sy8trZ+JrPgg1G6unNurfzodzRS562sUYVuPpeTr67SJAnF0lKsUwaYzs9v6PBTEoaWiC10/yrUNmv5HcBoZSVWeCipq0yivydJEuuis2nbtFIBaYjUmzyPkfuOwLnBBW/A7kffTwPa6ouKtt3bIkobplHFGvkDsVnFJhP12M3GWwFM16vYzZiNEsZnzsXXink/PMDXNyeRwCEny/3NoJgfMblznfmFEEXPj6LPdDxHWVPsb/XmIkkotHW7aZi4NpFoy+nGaUqlU1kI7eOBpGNDipEobIRdiDChmzRU6WSUL3mSLg+xVtwK1JH8NYrWaHuWTFvfDZfDnQ/1P9cO+c4+YP7IkRjFAjFSVolBoUk/fd0m/JSMlUCTQKrxmDxnfWEhknuT57ECJCvLToOMSiO2TlpL8HT9rCwZv/Q2Ji/8Ek4mHNsTSe9FDCS9h9An4A2kHf5fbzYwVpN/SeMrPXQ91bWrWRPd7HR/Xbcz/SVRY6Y0VIsk8XwtGXvkRcp8k1OuzEgSoRxVweLUN72ccWCu9cQOGnu/WqWpHUXmSVCns0Tipes0p7ARNvRqomnN/m29dazIsJUbdP0+iiRzCYRpAAAgAElEQVRhlh+JXsxr+REKaeJrKpnMpovh4kMVhASyLg95L43pND7Ak3NVFL7cbTqNGnA9GkFag0ypR/OQrYFLqEcLMRLX0rumaaJmHCPpQMQqf0hdx25EjY6lrmPTi5UyRisr/tIDcVcQq0YO/+aDOdnYrsThXsRA0nsE17z5OZvqz7aMTrXncrX7x2yTf0rKTdJq09DeAPIwHCD6P2/i+aH6c9OkUdMuV2e+kmO/71BUaaVzEyjSKGd0kpdp6x2iNwN7bdBtJIHuIIDSGC4pCXe8O4zdqG2C6bvjafmdlswtpSttpByO7dQzNzmT+Vs6uvekrtsqDm1SCX4YJFOQKU0+F2t+lTSbPPdkGd6LS1PI7/Tkrk53oyNxEEDVnOcjY6NLa7SrXYMafWvCMWmaGKFLXcffbUmeviZhPa25bvKc0cpKvCmcdGxf4nDPYSDpPYB3v+UXu6ZJ6u8c3O2yMMewaXxt8uLBfbGeebOoWisxmrqJ0kNeZJQrs3iMEnN/BBfAgXPnAzFXNHVDXmRx9JVWaNSpMMqySNxK/PMLDQfO3dgYYytGrHlTfN2W3AV5g2Adar03wEe1IZb1kTFtM4vWMWsUfb887/hSKyHfwiqz6VnMpge4o7i1JWdrvn/XQ5k1ObP5m5mIvzHGKd/6KA+1P9fOCXrwSox4p2ec4e1HszUAquLstqKjyX1N9fjG7j9gNaZRw/9wLc36ASoWqEcjT9CBwKszzohyR5Mk/jzJlPWzzvSf60SYW172ZHz22ZGsk+mUYmmJ+SNHKJaWok1qubjITsANg2gH7Fb877c/b0NysK173rqyQ21KbcVGu4YnZkgpV2dUs5piNCLLvTlS0kg8j627hqQjrxTzWYyWNTquZo03SUrFk16W4pwjHxG18GraxGhc3xN4graDB/RcYqLmvg8HJgrORCig48kBrfxhh81mtCV1fSc8PabTrq0aM7RTT7RiI5nishDx6jE6FUWPq9sI1KUpEvTeqihg3+3R8a6pHgj5Osl0DqqRP04tSaFdW9fVc1ZjmnzdV42MRrH9WyN1L5us+ch8dMR7SpeHqIpzoiauXY1NkjAKycZ6NCKZTvneW97D0z7/pxwqvwjvPx8uvxwe//gt//62HafxINqBpPcA7PirzSJjoC1zMx16/eYUaLVmrdoo5kcd/bmpk/ZGYCQO1aN1jX6dtnp06M1DAvEtaXt14qeAp+E8zmjKBXTMmaxXdXst3cYV20Ci5Aw+ch4rQSeJTyDSnZhiS+uq0LBide6yaXxEbGucwUe1SpLgydNEsx3StHKHatNpjWtSmhApz/bvpxk5v15xa4icD0A6pRmFm8DsQCuX2BsBtP7Qa+e3r428J3RVFO1/7myt9ZDOJrjHPQR52/s8WQPT1L+/0coKmelY1ATid9/xQV540xvZp0MBPvtZeOpT/e8njahP30j6hPpJi8iiiPyJiHwi+Ld+o4gcEJFrRORT4edZYV8RkVcHb9YPi8hXm3WeFPb/lIg8aesznnro+GqYiSn96Sm+rTvp7KtDXjvr9bw64oTwomtrqtAhALb8yerJ2i6eF2nw2kh9Z6CWs2nlRNOwFNzqZnjyXqp8c8odtRnxZTopnUismZ6WNSPYkCS0znb2974xUn/fcZKwmKYspqn/Pcui3/RimrKQNZ748jCKav1Ad3irEuU0eDpbo6SgPfuTKnlOvB6dJDFBV49Gfn2ZtueaO+IJO84zpLtuHl4vbm2jayX54lZ0TmKTr3utO0lgn3/NPfFLcD/2pQC4H/im9t97JrG5xZYCapXJM276Xy1BK1ZX4bLLOFlwzld3HO1xKuJER9KvAv7KOfdDIpID8/junnc7514ejLKfBzwXeDS+5fIivJvU7wBfLyIHgBcBF+Mrca4Lvq13nOBr3xXodwRGa1EzWUWxmQwS6587tdWt/us16czs32uWsV4h5nxa66zb1pxrb/mmaqLsyROTUGGhpW9Kmv2OyWyUMAsyh/p2bIZ+dUfmXOfGEBN++G7ACj/BRZ/byFuThFqKVyaVr+bQyPmuh/qfGsHOAjnnedcoKZl6YlQTJYgTTzRC1a5B6hzmJ+058iNt80satqeTDmmPslVm8zf7mwV4sl4/4A397c0DL3mQTXA/8vANn5173EOQN97WSTLWoxEEW1MJCcVD61/c9LPn5ps3334CMFR3nACIyBnAtwBPBnDOTYGpiFwCfGvY7Q3Ae/AkfQnwxjA1/B9CFH5e2Pca59yRsO41wKOAPzpR175b8P6/vCxGlfGrf9NKEflctmGaihJvHvRW1aZtRYWW1VktWPXlKDmkSYyerdQBvg7a3jScSKxLtnXHCjXl32weoEbA5UoVE6FJKrhcmFRVXGNxX+ZL8MJzbTKxDnRWr44/XWuMpNs0Ys7CtfV9pqEldpEZLsGTpxLjciBrlTSmB0wUG6JbZ/Ts2RjqMdlKmKpCaPHO16M2TDL1a5zx8VZeWT3fR9n1GKpA/tmEyq1wzsgxST/n67V1KK1G+gDzN/txWOsH2hvAJnBP1Hrns8NjE1xwvpc4+jj//C3X3X4McseJwJcCtwP/Q0T+SUR+T0T2A+eqkUn4qX8l92WjP+t972Z7ByLyVBG5VkSuvf3227f/3ewArL5sR1jZ6gff2ZfERF4/stYOQAs7Tkslig2ySmcEl3TOGf2hp96c31UN4zSNxActEVsbUa200FFS0JLttOw69AEb9tU4Ss9VBMIdJ4nfFoi2EPEyRmjdVvmjPxgW2nFVdoqK3kDifiplWLlBfwdPpkqQa+f7CFtlkWocZwnaOuSqKNqp3lpiVx5qI2fwP+M8wo2lbzG5qZUk0K6nmL+5I23cK1x+OczPd7fNz/vtJwshcXi0x6mIEyl3ZMBXAz/vnPuAiLwKL21sha18W7fa3t3gjb2vBLj44otPiK/rTqBfekcot9Pn/Y5CO+qqq123x9n1lOBV/7UeHhnasGLP343agWDe1Cb1omQQfJkVKilYiSITQZyvs55fyONNaM1KFs5xK3QGvuqxkUibJnYIAowB6prS1EMDndbx0t48jP+HrQpxLjToWKJWP+gm95Hz9AAsPxD2hYhWpj5CrsY+km3yjn1o1IpVStF1NSmYBpIdTbo3hfC6cyNvOGUrUJrcE7nKHfkR3A8d1Vb52KDJwcsu8xLH+Se/umMowTsxuAW4xTn3gfD8T/Ak/QW1BQxyxm1m/838WW+hlUd0+3tO4HXvCnzwXf91oxVotCOVri5tH0krbahM4cvtYLreTRzqelppYSeKb+YR0p8wbkv0mtqRZUmn8gJ8JcXEyB/RE0MrKZxjLN45T0v5ZrRdgdDq19FbNSBKJiLR8CgTIQueHNaWtK+PA53uw45rHmYgbGP05nVfedEhxrkjUE5IZgs0a+dAesAT6wzvD10uxFZrbev2OrGvi44RuS3fg7aET8v9klbuEJkxacTfQCzBB3LfNnK2ePzjT27JXR9u+/yk9xpOGEk7524VkX8TkS9zzn0S+A683d/HgScBLw8//ywccjV+fM2b8YnDOwOR/zXwMq0CAR4JPP9EXfdug41erVm/dgxadJpD8o3Tv63VqF3P0WqwtjsR6IzZ6mvbnXM3jkw7+eiOkLJt2bEbMESuWaj6WFgYRfJfsS3b4dpsopGwTffJsqwzRbwK51IDJfV3hnCTUCc7E4nrN4CluvbbO28uEGc9hppWmpBpLI+Tuo7mRK5cjD4X6cy3V6snR8RoqY2kbbLQRtb5kY0Ena5EHb9yM1+fXY2j9OL+87du+Lc5FeA45skspxxOdHXHzwNvCpUdnwZ+HP99/S0i8hTgZuCHw77vBB4D3Aishn1xzh0RkV8BPhj2e4kmEU9FvP8vL+uQq7X5VKhPR7QdNVHvdL0O0XTPe6PTPdia6DvaRN++IHf0k4r2vJ2yP1uRkUiMgFVnVnK0ZKszCaMOHAj8fqMRRSKU4Rjr75yJUCkBBxMj7RAEGAdJxY6u6ntLT5qGm9bXDcG5qGFDO1xW19Xa6plGt+sHYPnC1oMjJAXtOCmdbALEFuv1hQXfSJIfAUpPtrMQIc/f3JK0dhcq6ap8EV4f5UvhWtOO7j+zMsi3/9w9+2PbS3COajY9+n6nIE4oSTvnPoQvnevjOzbZ1wFP22Kd1wOv396r2134+z9/AbDRbU6jh6YxI6+Mk11Hkgg+GhvXMJJEMETKixRxDlvUZO1Mm9rFqS7092GjiVPTeLnDEnI8Rj0xaCPgOGE7lOXFigttMjESRGYi20nTeJI2Y6qyqurILKXzE741WWgnrSzNZm3UHEhdr2XJrAng6v1thcb6IR9JmwGxAHWBj6g1WZf67sIqDYm8/PY2Klb5QhODqm/bbkZNRpromWwSvyVkInz+4b/F6QbnwA2R9ICdwN9d7ZWb/jgs6FqFbgbr82wrL5TI9bldX4ldydyS2x11zWKWdZKRmlQU5+J2JxJvHlbjlpAstBq0lsgB0Rh/UtdMgINZ++d3ayBOjcA10l7sdQdqdL5kNGdrU6rnslNX4uel55rNYtehTWw6N4Lyvp6UbeXG5EIfPa+biSpp0Ec1+pVWE44e0unUJxZHRlfWcri1Q21EDZGUR0nlo2Pdnk0YJRWFJKctQYOfimb9Y04nDCS9w1DvC9V7N4OdTdjvFrRt24o2cm4Tb3Y6ixK4M5UPGrWKa28M1axB0pQqEGFi+lz6VScdOQZjum+kDT3HOE2jXqwVGUtVRRmIEzyZx/ZtiI0wh0PXok5KUZLWY2w0rbJFf6ILwB2rB5G5L+BWHtRqzqo1L1/om1F02/KF7T6aoFPtWPVkGwGXh2AW9tl368bo2JKwJgyD3pxJ4qeJGwmkU/d9GuPuApZTGQNJ7yCuefNzWtkiJvfSDQkS3/KdbSi3s4TbR9O4GDUrufb3V+MiaMdTZc5R5ClM6+jBoUm4cRg3hXOM0l6VSNoSiZUnst6NQLcVJrmXiXg3O+1AlLacz66hbeSTUDZndWTru2ETjbbErluyl7cEPbmwlTV0YOwsRM1an6zRsHpDK7Q8zm7XTkDoVm/o9sLcAADyI52E4CipPFEHbTrLytOeoEXY8m/9VMdA0juIaVm3kXQiNKkLhBw8n+s2o73pVBbbgBJL75qOm5xNKup2vSk0iaM20bES3Ng5sswTWmkaPCaGRCfOj98apyk1cKeZjq3QJhJLjn3CrvDjqtRDw3b/HcwySk0EhvMvhRmEtrwuDoK1uneIolU6AWL03THlP/J1HbKMjSXWP0NNlDS6tU0m4xvb/bRUT5OCmhhUb43xjV1HvcmFncYT1cp9S3rJJBC3Sh2ZCA/+6DP4l6949T3+W9vzkK2/aZ7qGEh6h/D2331G+KNLWlJNJU5XaYnVP7ct3TYRGCem9L4K2ug2TvXu6ddJKr6izBCn9bmA7lds1XgzHStFd1K2TRYWIqCVHIbYO+cy57ale5VzHMyySM62fK5jPxr2tQNidd2loDVb3XrSNMyq+Y0udSo/aHKvybskrYm+uSOtP4d5fZSt+sYX69+hxkmhGUVGd/ib2OhzrcteIHBJVxiHm1Qc8RXek04lV7+T0xXC9sgdInJ/4I3AIXx315XOuVeZ138B+A3gHOfcYfF2jq/CV56tAk92zl0f9n0S8MJw6Eudc2847gvcBANJ7xC+/2dezZ+97pkkKZ2mEKs/a/egjab9Pr3Ov7qh0ag5TUhMo4vub+0/oz9GiJQtwUZjJIglb0CHHC20OaX/Wp/c+3KHJVVoybQ055tk2Ybkn1ZrKEGr9FGZ69MIW9dbq9OunAGtIRF4ItUEH3Q9m5u81actiQciHiXdypL4mhJ7iNKVaFWPnzRVLJ9TVz71IqFpKE15YLxhAh9/WOST0wvbJ3dUwLOdc9eLyALesO0a59zHA4F/F740WLHjxm8DSe8wmrqhSVuTfUUcd1WkVLN+azidr37RoW4T/2db59zpIkx8ktCiX89st9vX1SVOt2k0rZUcMdlH1xvDOuF1zhn0Zn1Nk4Z23qCVS/Sn7Ursa9GaVHSzs1pfjTpviVmjaNWHU5PQs51+FvmRVvIA9qU1hYSkpfg6cdTwyLZ8Q8dXpAqyzu0hEo8Sj/kMi+CFHYkbuP7LX8Hpiu2KpINfkHoHLYvIDXgvoI8DrwB+kbbBDnaB8dtA0rsAVjPe8FoqJHW3NE8jYkvY+vAOeFncvtlkliRtG1nARLr9573OuyhHJIlP9PW0ZkuYtmkEiBO1S9eN2GNSUBOIqjMnCeNeKZ++vqHzMOjONrpeWzun1YgnF/o3oBUa8YMwsoU1KLIPaxGaVIEwy1hfPU7TNtIPLdsuVGVIGroN3SgaQOl7WaqqVupIRh0SL40ur9ve95ArNvw7nlaQu59EdO+WlAuArwI+ICKPBT7nnPtnkc55jsv4bTswkPQOwrra6cNv73YZqqG+JWagYyGqZDw/HnX28XMI25mFSvB3hK48JVcrSWg0NzFjqDbbz5olTUK5HWHNIpDYYppSaVdfWHMSosk4ozCsc+tsFuubiyThUBiUqpF6fE+u68NRJAm3zmbcOpv5yFkd6BTz4durbbeGjWZJStTzN0dted9ozejzfkiA3jCglYEWgSppWKphYfx5FtOUTObit4nFQNKTponJWBndEZ36VJPW+YyZCEsQBxIMOOZI+qCIXGueXxnM1zoQkTHwVuBSfPxxGd5yYsOum2w7ZuO37cDwr7+DyIt0g0mSwjae6NSUatbAzNYlNzS1d6uzg1ztWnbElf1po9woQ5j26jJch/pxWOnBErTCbi+d88b/mvTSqDeQvnWrU2IvAhlVwC3TaWd9TQR2mlrMDUOPH6cpy/UWUTFsrOLAR8eVW8Gtn9sSts4vTKZtSWG4GVgyBd8YoySrycoM4uQX6zmiWnokdvs56A1SpDOUwJYzns4Q4VirOw475+7WYUpERniCfpNz7m0i8h+ABwIaRd8PuF5Evo5dYPw2/PvvIDbrGISNLddqhq9ImuB2FwbDak004F3saEhqb0Na7M9Yc45RknS6BjPxcwF1UolGryodbGZCBK1D3Phu6na1oiMz62bgtVjnKE10bhOT1pGuX7UBxqDfnEdL8PQRI2iNnoPsEC1HIdYkh2e+4gNaaUNJuskpm1XGWdYm95Ss1aMjlM1peeLBsC+0Qwn69drQnbPYvyGV5saV9T7/0xUi21bdIcBVwA3OuSsAnHMfofW1R0RuAi4O1R07bvw2kPQOwk7Fbr03GqpZ130O6Ph0xOPTjcRude1qqlqpRJ1Yq0kK9dlQGQNiZ5+17iydb3Dpl+mp30bflQ6I66mrXNY0kZTiOc25rWdGXDtJKKsqniNWgRji1vPdNJ0yazJYfVCUNEbzt7SEmKZAw3LjI2pLspOm8dqxIfJOM0m+5D9C6GjESp6RoGkrODSyzozco9apWY/kgU3JWs9hE4enN6RT+XQceATwBOAjIvKhsO0Fzrl3brH/jhu/DSS9g7Ayh4+qu00qxxo5+Pbv8Ac8aiWPpnFU04Z9o4zlEHEuJKHDsWr85O5A1pv9IVhd2kob0W5U63dd6+tcGjLV7Zo0VBKyESW0Ld/WNe/WYJCvhHbrTTfw6X/+O9ZXlxnNL3DuV3wTo/s/GMATtJbWhXrnPgkWScJy8MYYJ2nsnrTTWipmkVhvD+V2eiPR99CvBY9dmOFn5Vyn5lk/lyVpuyy1UccmaoF4Q7Q3A7220x7bFEk7597L5nqy3ecC8/uOG78NJL2DiFF0GI9l/Tv6LdcduSNsszMJdXvTjMjnUprExbFYM1oNerlpWBglLN1eRvvShf0ZBV0PaCWwSYiErSxRBQKqnANTzwt4LTpJGON15MNVFcdbRQtTk/RbDBHnoSxjEshJy+8OVxW3TKes/tu/cOc//S3UntZmq8vcct27YdrAfR/cVlSECPpglnEwy+O3An3v+9IpmbSjtkqC7GA+H02mnjO3zlK2yqzazxIrnWh3YuSIcZKQ9QhX39diIG517dNr0eSjatL9kscoc9BG5ac7hKEtfMAOYLP2bn2+WTOKPQZaCSS2eidCFTw3lMQzEurMdOpB1JPL1baHLS/STvSpXW/Apm3XNiGWmWi0D9VjVR4ZpymHQxIQ2oSZtnxrfbP+HCcJX/jY+yNBR9QVfPL9cN5X4Kq21Vqvs6P5hvdtE3GqyWPkBKuH681jSdaonCfmRSP36E3ERsu6hn3eh0bImnzUz6E/QV1vaLBxbNhpiW2KpPciBpLeZehMYtnEaW5DBUjiYuJQyVonijeJi23m/ZZi74jXdIj6rP2Zjz6DhmqTVioLgGkPD4lGK2nY7sVxmrZG+lXFYpq20XkvWRY7BftE7RzN2hbTrtcmjLJVspEfRbUWjEhU3tAbiEbUKk10dF57LSGq1sabsSb99H3T7by0+rRNFupr+rnFBh+Rjo6vkXT/JmH17wx42X1/efP3fxpBZPDuGLADaBoXteiOp8YWsw0VSZpEG1K7v53UonXXtlLE2nrq7MNydRaJOi9SxllKVVUdaaLvEa3RuJJWP2rVKLWkJa1J0Jlj9NjTpq1Bf5yOEl6TfWPcJkSd7BtHKcVXojRUSIfgYkNOr5rC2qDG9xHI2lqjAt0oWW9GJgmqpBu1d5Mk1c/RdhTaJKpKL7bqQ3/++v1ecix/RqcFtqu6Yy9iIOldhA0TVWrXSS76fbrt4HY4p6+pzqIWnRcpTeNwpmxNk4GjEJXkRca0rJiWNc2CTyhmIixmWWw8UR+PEq8zW5N9zLqWADUJViat13OJr4E+mGWdZhDrXLcU/KItaSUP+8aOJg0gacaBr/gmFrIsklwmEkdqAR05gbqOhDw2JE7w0rCe1Jm5edg6b71WoEO+Hf3YEHC8SZlqmZgU1BK+3t/AlQ+4fJO/jAEwaNIDdgAqSdxdZVFrjpR0/kizke9AnCZC0/hKiCQVivmM+YURbpSw0jSQtg0p1jNjvC9hYX/GtKyZzqWxEqTYn5E5uuOrIEa/GlVPmibai06axhMvkAVJI2tan+dYnhbITis3oNWxDwevaHW80wqJTAQe+FDuSlM+95G/pwrVHfd7+CM49IAvj+tMmoYCLyH0E3vgyVdrmDVxp9UoekzZdL2p+9KItUztR766f4n/lhG7K83naE2UCpGBkO8Jhkj6xCAUhS+DOmK6i4N71B8DFwA3AT/inLtjN1gCnkz87Vuf67sB2x6LzriszToR7cSUalaTz83FbkRfKZJEqWO5aR3lMIRiO94AxvuyuKY2vth9bDu4Rb9srE9uKlloE4cd7lqE+mmNYDMTCStsVUMGFBd8OQce8JBOWVpfM4/yhUoWmOTbJnJHkSRktsnEEO6kaWI7dhxgYM4LrZau8kdM+vWu0Z5/3IukBxwbhO337tgrOBmR9Lc55w6b588D3u2ce7mIPC88fy67wBLwZEJN+RUZ3TIrO5F7WtfkhSeFfC5lfGYedWT19FC2z4vUT+12XYtPi0lv+0KRRmK37dba4QcbPadVnlgM0kVf/gA6ZNXqxj6iH6u8oRUkIVGoKHoVDv1yv35VhFZjVM77hmwmQ9hjOw0loWyQpgFN/Il0bh4aVauOrIiyTtDu+/+hrDat16SR/IBjhxx7W/gph52QOy6h7Xl/A77f/bnsAkvAk4nv+tHf4N1v+cU22ZcKmC5DJXGNrr2VqSexvEiZH49oGsdoX0Ze+GoOyUI1gkawpuwuViGIN9/vE3WWCGXjiXMzi1AL29Rhp3jHtUzFg1puZuI9KZaMP0iRJJRh0oq9XkvuHZI269uuP03oWTMoe/2WlEvznpQwJ6a6A9WdTYQfr8m0pVv3O30v/Yi7krbMz16H3jQG3ANINx+zVyEi+4HSOVcfdeeAE03SDvgbEXHAfw9uVOcGT1dCD7z2zB+XJaCIPBV4KsD555+/3e/jhKBcraLJUrlSBZP/Nkrr+HmYtnD18phbzKMcgQCmYw+McZKtzFCZQiNfQ4xK0J0Brkp64TrsOhW9r/xhm/VFVmKyfs8aIVdAEa7D6si22kGj2n7kacvfdD+NltVfJCb5DLFWQVe2XZIxOq7rVvIw8oyubyNr/XagN4g+Ces1atWIto4r+vLRgKNB9qQmLSIJ8KPA44GvBdaBORG5Hd9yfqVz7lN3t8aJJulHOOc+H4j4GhH5xN3se1yWgOEGcCXAxRdfvCf+B3zPk6/gHVdd6r005rN2mrcde9WrlQZjSxomuuxPhDoVlnRWYJoizsVp4Detr2+MnENUWySJlwegU+Mc65ZNZGpnHULb+h1HPIlwOETKmvSLNqeu9X1Wrw7biWe1WhvB9yNhvT59rpNOSkPmGXDLbNZpWT80GsUbiG12sdJFrMowEbK+h0lIPOp70DWU1G15nq41lrZ+3MpBZdPwkvu8+Dj/ek4viOzZ6o6/Bd6FN1/6qHOuAQgy7rcBLxeRtzvn/mCrBU4oSTvnPh9+3iYibwe+DviCiJwXoujzgNvC7jtuCbhT6DSghCqLLE9iHTV4d7smcYCfHJ6kwuryLJbakfpocSFJqKZ1NFfK8razzRJup6xsC1kDTOIQOpIEtF2JE2g9LOiSd9VbQ1+znYh9gsUQtCLWIqfdhpVCBNKUoheZ6rn193GaMtbhAD3tW9vYM31/SdvybhtbtGbcRsH9bsCOPGJgk5ZD/fO9w16MpIHvdM7N+huDfPtW4K3BOnVLnDCRR0T2hxliqsM8EvgocDXwpLDbk2hH1VwNPFE8voFgCQj8NfBIETkr2AI+Mmw7paDdgtXMTxCflp5odaK4QnW5vp2pYlrW/rEeHmUdk2p25FUk3hDldoz99ZqUTM3rUQ/W11X2MMSlUbN2Dk4MOcZmlaa1GYVWklBZY4NLHG0CUB9W37Wudv2kIRgXO5VfXFsHrcfrtxAb1VvpQn9uth02dnVaYo5SyN39EQzYEsYsqVUAACAASURBVBpJH+2x22AJOnDYw0Xkq/XR32cznMi/mXOBtwcT7Qz4Q+fcX4nIB4G3iMhT8AMffzjsv+OWgDuB73vKK/nL//lsgEjO2chFc/9slHYmq9ihs7b8bgYsZhkry+tM1+tI4tWs4cDCKEbQhSGzvr6M60odSsC2lAy6erYSuHpz6JqHq8pXflipA+PlYQyHdIKLXps1HoKNEbWSna0aUbJXz2dbmRKj8CShCjcs266tUo0SvCYSl0IDzDjo3NZUyqL/+cTrVPnEJBaHKPpeQvZ2W3jgsCcD/0or1zrg24927Akjaefcp4H/Z5PtXwS+Y5PtO24JuFPQKo4K72qnBKsmSflc5s2SRgmMoJrVnUG1AGntmM1qytWKalZH6SQv/LHjkZ8SUpmOQXoJOtv9p1AnN5tA05+2LnlS12TGrhPaaSpg5iO6dsI3+EhWSVklBcXBLNugpdtyNnXWw5Cwkq21FtXyOH39cFVRhZuEPU71Z4ClcD69KVhduS93xCk25hhNVNppLVtJSgOODmHPyh2KHwEe5JybHnXPHoZvX7sA3/343wTgL37/WYBpZDGGSsX+LJbr5UV33mG5UkVpY3V5SjXzxkk6iHZ+PKLYn7E48qQ2aRoqY6MJbSLOGilBq7labRlotdsQsd46m0VtWSNzNUmyxK0/L5yb60S6unas0DBasI1es6A1W0JUW9CyR/5WP8/w3zSUaCemsafQG0Vw6NPjbaONfQ9649BvJmrzaksG4+dnyv4Go6TjwN5NHCo+ih+FedvRduxjIOldhKZuaOq2/Xtz0yX/us4uVE9pL5V4stZovEld5/h1U5YG3Wg4aq5mu0KJShNn1N0Sz0KECT5yVnLUluh+Q01pSuVs96CVJ3Rbv/wt/k5XX1aCrpyLtqk6K9Bqwv0W7n6pYqzYAIqqIjM12jZpqKV/neYb0yizWVJ2IOjjwykQSf8q8E8i8lF8GR4AzrnHHu3AgaR3GfrOd1nenSKuEXQ1a2LJniXqatbEyg47MCBJharpzhFU2JZpq1tbKDn2m0GUlFVC0eSgRrSWjO02a0TUbxqxlRmW9DbTfdU/JDbHmFK3/vuIa5tEHrTugJbQF4MXCYRvHvia7olra79tZyP05A77nu7+n3zAsWDve3e8Afg14CPA5q3AW2D4+9lFsN4b2SiJBJ3PZXEb+AoOIMoZvmyvrQqxiUYLGz3qc0sshUjUqfsRoa1osFGlOr0VJtkIrc6r57E3BtstaIlar0Oje4W1NO2Tqa2csPp1v1PR3iBUlsGQun3PmizU61FMjD5dhM/Ljgbr30SKJOHnzrnsaP/sA44Bp4Cf9GHn3KvvzYEDSe8iKKluIOg8iQnCcmXWqZ+2MoeW8IXVOus6E50qOsRIW4NsydQibq/r6Kcc19LjtXXaEHxJF9ZfOVY/9EjaXp8d7WWj1q0ScVHLpi0TLEx1SyRg863C3ig6RI6fcl6F7ZiEq71W+41Br2Eg6O3FNg2i3SlcJyK/ii81tnLH9Uc7cCDpXYSNI7O6wwD6Mw3b2uomyh4+ik47hN/UXf3V/uzLDP3qBWiN+2OdtD4XAZUrwr5qYt+RMoJ22yf1/jn0OiLx2Wvs/QeN5Xzim1mUbIskibo00Glx1/dYhKTgpK45bJKBHbmDVovXc2n03f8stcpES/nscIUB2wPZ+3LHV4Wf32C27WwJ3oB7jv7ILAj2pYXvLtQ28WyUkMwJ5WrFtKx8NL3uKzssQdu1XFlz9iihHgVCm8060bCtG15IfN21damzkbFq0bp9EuqJF4MBv6J0jknwju5H8RYxadnTkm10XTrn29iDDr2YZbGqQ5t1FtM0tpxHXw2RbpWHibK1NtvaqWpJYCey1y5J5xjTVq3cb9RtFLNSyU8cfMHdvOMB9xzb06wiIvcH3ggcwmvDVzrnXhXqmC8J227DWyV/frsslJ1z33Zvr3kg6V2Ca978nPi79ZG2ycH+6ypzaJdhU7cDBKzV6epkRjZKKOYz8jSNiTN6jRlqu+kSP00kuuEBmJpj9fyAjd4atqbYPvrRuUKvo6Mvi3RuBAAY7+lYkaIJPKM/Kwn3B7pqLbcdHKslf/6D6jb3WOknErupA9fjFnt+Hptp0wO2AdsXSVfAs51z14eO6OuCs+ZvOOf+K4CIPAP4JeBnOE4LZRH5L/hGvk2ThSLyIOA859x7t7rggaR3EfqDZhXq6xFrp3vyh9qabhZBg9exi/2jYHfqIGmJC0x7tyFiaAk4kq0hbY2wl2ynX2JMlcz5+5UkFlbTVVJVgrZTVUqRTtOJnXASiTaQcKxrNrJD3yyqSBJfN61JyWSjJ0eULiT4exh9O14/bU223jR+7MDz7vbfecA9x3bJHcFqQl04l0XkBuC+zrmPm93203YFHq+F8tn40rvrgOuA2/FplguB/wQcxnvqb4mBpHcBOlF00kbATeK7EAmd/f1JLUrQsUNxEx20XK0o5v0/c9MEhz0TCWoNcGYI2JaOdeqLe0lAbcWOLni0TS/Rl9rsnxmi1ejc+m9E8g0EeTDL4g0Eul2AltzHYWSXjsGqnPPDdE3U3dGXA9HaiF0ntFj0KzfGaUpV1xu1aVpPj8W0O7xhwPZA5JhN/w+KyLXm+ZXBIXOTNeUCvFb8gfD8cuCJwJ14hzo4TgvlIKX8Fl57fgTwcGANuAF4gnPu5qO9oYGkdwH0j0/rohVN0wAJTdN0tGYg6tBK0NqNGI8NEkkk9qBl61BajTCXDJl1jOul7QK0NctViBhLs0bsVlSCNNfRSRb2EoIbouck2TRCLkOpYD9hp8e7quk0qiwFaWRsE5ghkl6qqo4cEmuyQ8Kx0zhDW16o60b5JFSx9BtcHnNme8MdsJ04Zk36sHPu4qOuJjLGu9Bd6py7C8A5dxlwmYg8H3g6Xs7Y7KTHbKEc1q2Ba8LjHmMg6R3G+//ysugl7YnUR2KqRYOPkLNRW0Ot0fPq8jRWcyiUlGOttd4AAsHX0xoBXCJIlrTaNK3GaytA1D9DPZVjxOscldnXWpF2hgeESNiSsK7d7xpUf2hN6GkkqwNgdcq47jMON5VpWTNXeK29DGT5kKLoJA2X6pqbptNO9UohwuJoFK9Rr9tG3mXTtDe1TSaR28abH1j8xe380xhgsY3VHcEa9K3Am5xzb9tklz8E/gJP0jtuoTzUCe0gPviu/9p2BAaCts/zMHtQG1Ps1z0bOTeBiHzE7Wuq8yKlmM8o9o8o5ketjj1t5RExUaN6VRRJwgg/MXG/a7XhTqRr5AYlZdsC3rHvVNILz/v2oZ06Y5N8XDTnzfo3D/MZZiLxs7DEr8dr5QfQuUnoevt6N4vCnM++T5v87L+u1q0DThyE7bEqDdUaVwE3OOeuMNsvMrs9FtABJTtuoTz8be0wtkoWquxh6537+3kN2hJ0GhpgArnnaWf91eVZbIphBC5E0bbcDIiVInodi7n/MymDbFA5F6NvMDXLrh1Qa431oSVFtfy0FRBKcp3oOkTMavPZn8RtCXMWtPlin9ewF7Osk8TUNSxhK5raMUqNxqw6NF09Pk4jN9887PUMFR0nGNsXST8CeALwERH5UNj2AuApIvJl+P9Qn8VXdsAusFA+KkmLSAF8L/AfgfvgRe+PAn/hnPvYibioAXTGaKnM0UeSio4obAm6CNF4nna07iQVilH7z900vtyuH6VWznczTus66t7FvGNxX1tqplDpITaVuLZpxtYp675Fn5h7JGe39cvttA7anluPbWrH5M4pZ6RClvnhrzJrqIEiTylCqV0ngRje+3St9t2dedo5lyXd/rVZPPKMXzjGf9EBxwONpI8XodRts4XeucX+22KhLCJzwA8CF2B41zl3VIPxuyVpEXkx8H14reUD+CLvAngwfjZXga85/PCxXOiAzREngjcNiSGizrzD3iQWS9z2Na0KaeqGxDjlZUbZsoQ/AkYicR4iQJ1KHN81Xfce1QBF4asg7OCAjgxAK3X03e+gmzi0LdodUqaVPnRfWzNtK0r0tbVQori6PGN8Zk6RpcymFUkqSKh5LsNPq1NnIsy0vLFqyJL2m4W1Oi2NVh29uAecXIgPPPYw/gxfNXIdpi38WHC0SPqDzrkXb/HaFWHA7N4Yzb0LodUXCpss7D+3zSwWqsVpe3gcDgCUqzOfWMzT2K2oa2q7uGrd0is/c6OEfXkapY+mdmSzhsUsbUdesTHqtLDbtXFkHEZU2eG1WslhyVmMpLCYpjEpiWk7B3+T8Z9PHevJi/ngvT3zGnyxP4uyxUKSsGY0cxud9Rtj+pUtKnUUScK3jJ+16XsecGIgsuf9pO/nnHvUvTnwbknaOfcXR3n9Nu6FifWAFjZahq7uFiPsuvWF7pfaxeP6DSyrVUePjg0vTZtgyUgiAUetmrbLTpwZ29V0Tfst+tv62m3ntd4+luhtIi7eQEKUHTXpEBEXvZuDzn4EmK7Xnffe1I7CvL4vfHMQ56jD603qo2m/1kb/Er3uIkn46vlLN7yvAScee9y7430i8h+ccx+5pwceU+JQRC4GLgMeEI4RvFzz8Ht6wgFd9P06WunDxbFaliR1H/uzv54aLyWJBCJuNgyw1cjbri1F2/ZcOUfqpHN92cjXB2/mw9EnNbsOGFLuJf+KXhIRvJ69PvFJzlEqZEk7qVtRJAlp7Who/Uw6sk+j5Yv+/WVZsHldq8KNp/vtJHpwp/4zIyFKI9FJL0l4+L5nbvLuB5xoiOzOQbP3AN8MPFlEPoOXO46ZQ4+1uuNNwHO4F4bVIpIC1wKfc859r4g8EHgzcAC4Ht91Mw3C+huBrwG+CPy/zrmbwhrPB54C1MAznHOnxLTwzuSVVDZ0DFqiho2kbIlI1+i3iG+1XpO0ZK0EVwBZiFrLpmFFYM7o186Qq20lV1TmNWDDtBU9FjbKJLbuWJyL74UZjPYZ46aQABwB01Av3vn2oZ9JuPnoc1e13ZnT2icLq2mzoeU+fo5Nd5p5IcKDi2ds+EwHnDzs8Uj60ff2wGOtk77dOXe1c+4zzrnP6uMYj30mvgVS8WvAK5xzFwF34MmX8PMO59yFwCvCfojIQ4EfBR6G743/7UD8ex5f/8iXdp7HeucgQegw2WhH2rjuw+wT1zCTWvyaRuM2JKT7ds5fu07tdOkc9VzCaF9GXqTxNVshsRSc8mLDSxjwqtPDbR20diP2uwf7sseMbnJTnGO/8+58qmvb997/JtJvl7c2rnZ6jf1c47eP4L1tXQG19XzAzkFCW/jRHrsVgS8X8YUY3wcsHiuHHmsk/SIR+T3g3XQNqzfr1okQkfsB3wNcDjwrFJJ/O/BjYZc3AC/GO0tdEn4H+BPgt8L+lwBvds6tA58RkRuBrwPef4zXvqvxtd/5KwBc97e/BLREDb4OuprVJEnS2a6IJDtribeYH21ogNGJL/1o0Z+jHXhbzRqa0uvT49QnCG+Z+uHGi1kWB9WqR/NSXcduQOgS78HM/2ndMp161z2MBELPKxp/QyhDiV800A9Zwdo5iizBAXO1o2kaplNjLtVpl6/jZ5IXGdOyjsnUSNahakXfPxAbiNLcmCWZuur55GcYsIPY44lDEXkm8FOAcuYfiMiVzrnXHO3YYyXpHwcegv9vo2zhzAm3wiuBXwQWwvOzgSXnnMqa1pQkGpY45yoRuTPsf1/+b3tfHy1JVd3721XVPc2dO8MwQIySMYDBvGiyFB3FhOT5gR9oiPiiIJFnEImoCE9i4gcKfoFENDEiiIqioosIKPokBD9GAxpdMjKoUQkqo7CQRAM+GJmZS9/urtrvj3P2qX1OVXXfO3M/uu89v7V63a5Tp05Vdc/s3rX3b/82cJNas1bIhIhOBXAqADz84SuDcKIrCZvn+GELAF5ZuDPGQffxOq+6szYrQxqK49xlxi/7fcdTFuU7FwqoEXYCVANZMbxJKRkKWPaHjfvuUsdJVxS3rqL5rUtVkY8VnnJPHDl7CUT9pDCA/2ShwyS6XRkxY00BdDJzrzwokGbRQC83CPUhvAnCKQCOYObdAEBEF8A4mgtmpB/DzH8wnysiomMA3MPMtxDRU2S4ZiqP2DcnIROrdHUpAGzevLmeAjHGePxTDaf9lhveXGp2DPlHmSQJilzR49pls1pJlpk1St2P0FALwpDBjkGZGpxOU3QHA/xqMMAuK1wk4QzAF0sKPWpYmp0c1yGTBBRDPWDGDqnqs1WCXSvYL+u4riwSegBMElA86L5/H+F9uc8rYM3IX48B0ytc/8h2J8WgV2Cf6do6hoilxgJqdywTCCanJshRb9sqmKuRvomIHhVoro7CkQCeS0TPgSmAWQ/jWW8gosx60yJWApRCJncTUQZgXwD3oVngZEUiLEwRDDXYTmc68QSWmvSlQzqfbPe6udH8sGwKXTEIWA9aJEjZF7hvTBDaba2NAZSNYWX/jjw3LauEbqe8c60J4s6rqim7MwNleP2njiIH2mnmedvhfev49r77l8nBVrvxI49YYixUxeEy4mMAthLR5+z282A0REZirpH2PwbwPSL6MRF9n4h+QERDqwyZ+Sxm/i1mPhgm8fevzHwigBsAvMBOOwmmEgcwQiYn2fcvsPPZjp9ARGssM+QwAN+e43VPHCRGPQzCAknSUoRJS5JqFHlRy60OGwiU89kl8rpFgV/2+6WsZ+L3OhS1urBLizbeQl0TZESu9ZUnrmSTkbsU5a2rtvWrWxSgrCyBL0MYoYE2xlc62JgYdm4+k7xMxOrmCRFjCqp2LKp7jSusmNPJMI7n/QBOZub3zuXYuXrSe1Qp04DXA7iSiM4D8F2UvyaXAfikTQzeB2PYwcy3EtHVAP4DhuX1KqvPumLxhKefi2994U1eeEIbZjeWWjH/gAmis9xhjFZCIUlaaldLfJZbCXYXBVCw01J2DVrFYKLsDQiUXGctCSrjuwIKnpYJnbZMDfHKN9hEY0eYFepYafeVWTaJnHsftbYkDOu44+bzyWuYLuZ+koRw4EF/PY9vKGKpwfAiWxMDIlrPzA/Ydlt32pfs2zgXUaZR2h3TzLxrGFVE5gxbh5lvhNVaZeafwbAzwjldAMc1HP8OGIbIqkFdqMM30NUiGOMlZmUHlgBhZWNiNaWTgaWhBfxnTbMDyhCFDlsgCHdMW8Mu83TxixY4ctQ2IqeaN62MP6ASjzXb3aJAJyt1uA2To4ylhzFoCXXUfNJ4yKYokjTuYNRXu04A/glGoO4W+Lk0stuHjlpglCf9eSvn93kAt6jM5KEw7WWOB/BhGMpcxALhm9dVO02HBhooucRCQ8taaRl3TcwrSZvlUJOUvH81rr2UTQxmii+s5TtFd0PQLQoMrGF2yUOU4Q9NvZN/cLpqUZKLIvCv+yVqHrVACzl59EGVcC0rLMuqSl+D2zxV/PYjXj/sq4gYE0yqkWbmY+zfQ/Z0jVHaHUfZxN/LARxpxa0HAH4M07ngJGb+5Z6ePKIemm3RlCzx6HQFeSp3TfAYHolSvksJSAld1VVFdJi1YpyrClQKdbovoNfoVXnMmWJ9ZIGnLGsLRHN6wOzi1mGSUkDM7kdGPz0ILxwwiUPvs1Xe9CGPig1jJwXMk2mkBUT0VWY+atRYHUbGpJn5ejRorUYsPL569es8sSOgvsGsv78UTNJJREFT+APw1d52DAbOkxbPWScLhaEhinLCAAnLw8WgaklPrdehO67o/bKG8LHF89ZzO0lSNhmAKbJxbcXg/xCZJ4ykmlBsEKmKGG/UacaMO6yc8xRMg9z9UNLu1sPo849E7MwyZjjq+Hfh3649yxsrigLtTsuvEgwqBouCgRZ8TnTql8x6OiEp4X5rlAG4JN90kgBp6sWjhRKnu6vUtpNC6e3sUgZat+DqJAk2ZJlnfDOJS9sQi1d1qBCOOcO91pSta4aGK4vPy3LwXrdMHv7e5rP34luKWGoweFI96ZcDOBPGIN+C0kg/AOD9c1kgGukxRJXXPLdQhrctpeAJeboGSWpKnx8UDrT9h/+bLVODLaEFocNBsSlEi0NaSQFKKU6dexB41rpvoPQ77ATetA6jCEJPW7/Xx2ptDsB2Uu8OasWXipzx6CPOGfl5RowXCtQ3khh3MPOFAC4kojPmUgJeh1HsjusBnCZqdBFLi0rYIm8OW9QVrmgWiE6q5b0cnaDLBVst5TUgUOrzoQF4YkkZAKiEoEASjmHloTbgzutWXrGOXQ/UWoMgeShzpVkumMFEjoIo7b4GvRy92bxqpGvZHRGTgElNHAqY+SIi+n0Aj4Ip7pPxT4w6dpQn/XEAXyaiywG8i5knkao4caiVGVUNANxYUlbO1TE4XIfwflnQIkyQsJhu0CvFitqdFC3reU8nfiEKUPWUZUxi09qz1i2yBswlZQ9V71jzrSueM/y4NRPZH5ZSu6QoGIOeafclAkr6c0hScrrREZOHSYxJC4joLQCeAmOkr4eRLv0GjDzzUAx9jmbmqwEcDhPk3kZEf0tEr5HX3l54RD0qPQuLYgjPN+Q/J8haKdq2v6Enz6levW7utCrEQPdmc6ddIUJL02m1w7aGjlHLtqbn6XLwMJ5cV6HourTUhD702sS+bGt4rzM7e5jZ2UOva422vc+YNJxMCLtj1GsUiGgTEd1ARLcR0a1WnQ5E9G4i+pGtqP4cEW1Qx5xFRNttxfWz1PjRdmw7EY2iCr0AwFEAfsnMJwN4DIA1c7n3ucSk+wB22wXXYZ6i/xHzhzY6UhXomvkpaDlSd2xeYNBj9LpVvjBQxqqlvZY+Z3tN6iQ9iwcH2LeVYDYpqXaSLNQejYyJ8RS2h8SdNedZDHYYQhHvW5gkuvmsFnDKyDQEGPQL9HKu/JhJn8NBv8CuHT3M7OqbDuprUrQ7aQx3TDAWMHE4gGme/R0iWgfgFiLaAmALgLOsAucFAM4C8PpAz/5hAL5CRI+0a70fwDNg9IVuJqJrh+gbPcjMBRENiGg9TNvBkYUswOiY9NEA3gOjn/E4Zp6Zy6IRew+vfVYQZ/b+BvHmOgU9YTjYLRR52fMwa6cY9HJnpIuCnQEvcka2NvOYHEDpNYc8Zy1NKtthUQpQKueF3nMGoAv7WGsNt/CqRR1PPPzq04YvQSrb0khXYtQRk4mFShwy8y8A/MK+30lEtwE4iJm/rKbdhFJfqEnPHgC22wpqENGVdm6Tkd5mvfMPw7A8dmGOGkSjPOk3ATiOmW+dy2IRi4s6of6wik46gbsxa6BduKRfttnSxwz6BXqdsoGrXiNkbgg8ISUbh9YJR/3SHrGWItXFKgA8Gp+Gt67qZ+h+lJLyqcF9Pgmh1x2gO9P3qjMjJhNzjEkfQETb1PalVsa4AiI6GCacuzXY9VIAV9n3w/Tsfx6MH9F0Ucx8mn37QSL6IoD1zDxUpE4wquLwT+aySMTiQTM8XC++tEwI1nURH/QLJEVV3c4J4xfKSKvx7m6TFzbKem1jzG3owulvCJca1Z6GIULqHqCKU9Q8rbAXHh/GqInLnoTu8yjI3W/WSsxTgeVNyz3OdPtD4/oR4415sDt+xcybR00iomkA1wA4k5kfUONvgvmnfYUMNVxOXT6v8QKJ6PMwhv/z82XLRZ70BKDI2YtJOzW73DdYQNmAVQyUo+AVikvcLz1ofWx3ZuDmdaZaxsNW/zEqZdyWrVHpVxgkAgXaaMu+TpKYQhrAE2sKjxPjnIfC/io2LXxwYakkKaEz1UKvm7s2Wqe85cN79iVELCsWsiyciFowBvoK3QKQiE6CEUM6ysokA8P17Oejc/8eAC8E8HdE9G0Yg32dFZYbivHt3LhKIdWGtZS6oDDDY2pI775ujpmdfUdDq2N1zOzsO/bDzM6eC5EM+gXW77cG6zd2jDfdTjxj21FUul1BObj0PtQKeNMqcTgtDA+7hijeaUW8DHAskJAN4pgbPdvx296z3KPustLupGivyRzDBYBLwH7o7Jcu/JcWseiQxOECsDsIRhb5NqvxLONHw8goPzfIvTXp2d8M4DAiOoSI2jDJxWsbr5/5azbkcShMB6njYZKHIxE96TFDWLqtO5BoedKwSziAChVNl4KLgRPhezFsEhaY3tD2m9faSsW+ihsDpVKe/k9R9x9EVxXqknAJd1DglWu1PNnWY6m6Z835lnvVTwQ6eSihD0F3N/CBN56MV57/sb36niKWFgtYzHIkgBcD+IFV+ASANwJ4HwyDbYux47iJmV8xTM+eiE4H8CUAKYCPjsrdEdE+MJ3CXwjgcTCNuEciGukxwr9de5ZvpBNf7F8/2gt0vFpvC7ThNt53+egfHt+ZypC1SoNW5IwBVcWTBkGW3WNpWCOuDburMtQUvGBNskwQ0RDJiNACXE9EfU3efdl7Sgr/oVB/Vu1OViZarQH/8FtOwcveNqfuRRFjAAY8xcU9Xof5G6iPMzeKyDXp2c9HfI6IroJJLH4Rhrp3IzPPKYsdjfQYQTMzjCfrG0zAp9mFx2qExlve65ZR4jVPrTP1h+1OhqyVGGPdtl61HK740SEjA0Al8ReWfctYC0AxKJBbiiFlVRElDbLnyQtfOKl6j4XXhUbfc2cqQ2cqw8xOkxjtzgw89krE+GPSpUphehy+aE+6SsV/qWOEYdVw2rjqSjuJNVf2B6JDlb9FGcPVjBEXJgiMvkevA0r9DelvaOdp5oaXSFRrCXe5KBjE7IU+QuGlQb8ADwqvA7q7//AHKFfJ0pTQWZth/cY1rg9ku5Nial0b0/u20e6k+PRFp8/5u4lYXki4Y29j0suIrwM4i4guBQAiOoyIjpnLgdGTHiM89fkX4N+uPcsl8SSuDKBCqRsGr7ijSNCbLccB46Wv37gG7TWZL2WakvdeEP4n2JBl3lgnTfFLVfAiXvR0mpp+iPZ9mjN6/QLdmYExnEjQ7Rn/3DSVNefTlYVaayNrJejODOyPT+FREsNGslPrWshaCXprchRFYTqpW0NfTLfQm80xs7M3n68nl0NqHwAAIABJREFUYhkxwVKlgo/BFLH8kd2+G8CnAVw36sBF86SJqENE3yaif7c18m+z44cQ0VYiup2IrrKZUdjs6VW2Dn6rJZrLWrW18ysRrqms63Sde16jVnwL5+p9g16ZKNTxWU1Ny1qJYXCoRKGgqSOMlGq7BgC2MCXU9xDvuaO8aX0f+gkAKCmBRc7gQXnNoYqdTobKOt2ZgYq5F95TgjA9Kp3VbV/Ef/l4lKCZBDDs09yI1xjjEcz8Lth+usz8IOpj4xUsZrhjFsDTmPkxAB4L4GgiehKACwD8IzMfBtPa/BQ7/xQA9zPz7wD4RzsPQe380QAuISJfZ3MFQRuaEJpG5wx1DcNDhwFCUSGtL91Za2hqmjFSOacKRTgDrbQ4wkexkCc9naaYTlPjGfcKLxyjE5g6Xq453eF4neH2frRqDLVjrAT9IdtrUnSmMmy58rVz/XoilhETHu7oWXYHAwARPQLGRo7EohlpNpAu4i37YgBPQ9m49nIAz7Pvj0VJSfkMgKMsp9HVzjPzHQB07fyKQ0itq7A1Ao+6jooXNl6t1ZhO/YYA2njJftcDESg5zDYGrTt7h7Ki04oL3YLRqhZ1PTlH7X3n7HjQocetueD6xySswHQeesMcuWfxrOVz+OrVr6v/QiLGAgVb8a4RrzHGW2CYHZuI6AoAXwUwp390i5o4JKLUchHvgVGZ+imAHcwsTya6Dv4g2Fp4u//XAPbX4zXH6HOdSkTbiGjbvffeuxi3s6zQ3cIr++o8RqXvURVlSjzjbgxW5hlPMdC6LDuULfU0pKUoRWl16LlybhN+8MMOYSJQG2gXBhFGikog1tENQ+9bI2ulXtgjDJ1Ej3p8MemJQ2beAuDPAbwEwKcAbGbmG+dy7KIaaWbOmfmxMCWTTwTwe3XT7N+mGvmm8fBclzLzZmbefOCBB+7pJS87jjr+XY37nIFpJ55H7PYnCZIkcbHmsjDFTwQKjU8n27RhFHhdVGxptjAxRF4UKPmrdWXhfQCUJUjbaWkc24Zp0ZnKKtcihjk00F5cPRBTkjleoY8y+BKfl89IPgP9eQiioR5PTGpMmogeJy8Avw2jwPdfAB5ux0ZiSdgdzLyDiG4E8CQAG4gos96yrneXGvm7iSgDsC+A+zC8dn5FQlgeGtrQJkliGgHoZKBnfBJkEmBSY0VRIGullXBDr5s7o6f1pLNWgpY1onlROM9cd19xYv8wRnqD9bYHtkxc9k2nKbIsKfWgVTxa4ApsVOGJjPe6wgIp/8kmaYIkBZLZ3PPGjdxq330u8lm5gqDQ49ZsmJzxhU/+DZ794n+Y/xcXsYgYb095CIb9Q5Lw71AsmpEmogMB9K2B3gfA02GSgTfAaLVeCeAkAJ+3h1xrt79l9/8rMzMRXQvgn4joPTCi21I7v6JRx64Q49XLc2uUS+9Qh0OKhDFQjc7andQmEFUIREmSitEW7Q8JRdTxkV3smqhioAFgh21c61gdKMvDeVCgr7p2z0c2VGLa7lpVAlFCOwKXSOzWqAYGlZuhgY6dW8YTC1gWvqRg5qfu7RqLGe54KIAbiOj7MGIkW5j5OhgRk9dY8ez9YcROYP/ub8dfA+ANAGDr4aV2/otQtfMrFd/6wpsqyS4d3ig5zanvYdfOsR5yOwnoZ6mXJNRhA0GlijHx49Huvf1bF7eWUAkPikpiz/woDKyWSO46q2jmihhyrQct+8UbryvA0XFsCXe40Icq/gnniwH/58vO3OPvL2LhMamJQyJ6nXp/XLDv/LmssWietBW0Prxm/GeoYWdYyb7jwnG7r7Z2fiXiu197q+fZimHUDAw/Dt3ctaVujqwLwKnEmb6I9b/X2ksVxofobrh2WnbbazhrIYUpoQctTWMH/cI1IjA8aPF+E6PJkaowTh9emEJ/RlpXuyjKsIm+3zDk4T6PvPrEUBSMay45A88/7aLazyViaSEx6QnECQAk0XQWTAGL4GgYcaehiGXhYwYTfkgr3N462dLwVeTVVluaWteZyiqcaBEfKs+dVLxxyhJQloCtwfUYHvbvBuVBO460GG3l9ZbFOTWNcb1EplDxClfuDfgl4ZojHSKkGsqxjsqnvPVyvUK9zOdz1YWv2oNvMWIxMKHsDmp4X7ddi1gWPka4bdt5JizRLuOuXjy4hn7mSqODWLPmCmtj1ZnKIP0M253MhT0AeOEQWb8PONU7+U+wK+h5KJxoiUFrAaa8l3ul3b3uAA/cP+vuR58b8Gl34T2a46uRLq3o105Tpx6owyeyjj5GvHnXrFc3RlBzPnnBK/Di139w9BcYsWiY4LJwbnhft12LaKTHEC68kBCKVNPOyNuv54fG1fOoVbhCjKF40O01qR/TTspCFsAY6FBLOuwanqm/EoPeMRhgwFwmNW2Lq6xtQizi9euimqJgp1FSV8RTx33W+5JcPXX0DS9aMzvEwIdJy0E/d+u4NQOPPWJ5MamJQwCPIaIHYLzmfex72O3OXBaIRnpMcOvWcwFU+bth/NlR5Ar23lcMd03RiyfYFDSy1QYcMBKhHBSuaAMNwOucIugWhd+TMEnQVqEY8ebDe5Ku5WFsXBKDOiySJFQ2NZCnBhFRKvTTRO7uTScMB73SGw8peDKmy9Jj89rlx6QaaWbeawmLaKSXCTd/5Rw84enGMP/7N97mecFigL2xIUyLpkpEoKorPbOzb41bUglzAHCGWRethN1YPJH/IA4txnkfuy1XLd1RRL9ax32dN91OvfhzpcLQdv8uPyehCcpaBXSaRTjSAjHQunpRzqPnhGXpxRiyBlYbmBdG9H8SEY30MuKWG94MQB7LfS5yXRIw3B+OAwF/uOaYkpZmPNIiYa/JrcCFO5SBBsp4s+uwAtTqR4PF0LEz1ElaxsRhnwKq9yfxeN8wCkWw3ckqVDvX47AgU8QTGGrhkwN+b0jAj4WHc8znVcRwxxhgUj3phUA00ssIqRKsMwIylqFM5vnHhnocNrE2m/tds5W3qAtCmuK7QOkxS1VhJUmoDbRKEkrp+KBXqvSFPzRFYTqlDPqF+3FwIRsVfpF70j9G7TR14Q0ANoRhGusa+l5Q1KN+sAb9At3dfdcRXY6XJK0kNyV0NOiX9/CqCz5e+zlFLB0mOHG414hGepmg+bxAabCrc0rjVRd3DkMdOhEoMeusnboQioxrASYNCgyyqypUXnMY5pCXlHx7Cn36B6hfZVDIfXqdV3SHlYJqf0y0VnZdIQ5gwyVFaaQ1BU/fd11oQ9aLBno8ED3piCVHkTMGKPUwiqJAkvo5Bs1pboo5hxD2hDqTW0vHhfV1FIl5AfCKVdyailrntoNYNNu+heKRhp1SBEakv++NeayUVNEPhYrnGXBt3P1zyI9ChjKhGlYkSrd0KaDR4Q5JNJq1I6tjnDDBxSx7jVjMskyoJgJ9dTbP01PVdW6+LtLwYrSF85J1gjBrK3nOVF71hTK6OCDsTxgq3RHbTiqBpKgu6+7N5ujO9Mu/XROikFZYEooxzQzKsINuaqDDNk16G7phQEVRT83T5yt1qgv/2iP1bqzAC1QWTkSbiOgGIrrNdox6tR0/zm4XRLQ5OKa2MxQRHW3HthPRGxb8pi2iJ70M+OZ11UrQutAFUPWiXWggr4Y/6taT0u/2mhSD/mhvPNTkqPOgxTjL9RXWg/akRa0uhzbcgOnU3d09cF6sSQamFYOoj3HCUl2fz1ynYifH1oU/5HgxxK7F1prM6Xp4kqdRbGlssIDhjgGAv2Hm7xDROgC3ENEWAD+E0Xv+kJ4cdIZ6GICvENEj7e73A3gGjFLnzUR0LTP/x0JcpEY00kuMrV8+22g9u0KOgBesG6+2y0q4Xjf3qgMF1XLxkloX7pMkZEh9M/S3xIU6dFfwUB9aq9mF3qm8Znb2nJrejl89aO4hL73dXTt66Exltn1X5gyjJDRlfnf3oNynPzNrsLNWinZHhTRyRm9WEn55hT3S7qRGwjQhz2B3psoYdciLfvdpJ+K1l1wx+ouNWFQsVOKQmX8Bo+kMZt5JRLcBOMiK8oOq3H/XGQrAHVYATrSHtlstIhDRlXZuNNIrAXUGuunxui4cMQxGE6PajQWoxqLD/XUIDbSIJRU5ozvjRwmL3HjPEkaQ/XWJwt5sbn+EBhj0Tb9FSZLqeYN+7j6nsFze6GObHyXdsFc42NrYSpFLe03mfvDkR6U7M/C44jHMMX6YR0z6ACLaprYvZeZL6ybaZteHA9g6ZL2DANyktnVnqLBj1BFzu8T5IRrpJYRIkApGFUkM+sa4ZEg83efy+CCu7ehmOdqp+WpDbQ+ZJ4lCfVyI0IsmLn9InBCSi/kq8SQXTy6cVKhOxIkXKw11sxYDyFwSM6QVGg2OAkVRJkVdKXfBKvkqxyZAkLR0VZq2K4wY+v4sMOgPTBWkqPEFCnkRy495hDt+xcybR00iomkA1wA4k5kfGDa14XLq8nmL8o8lGuklQlMcehg046NJStSLoXpCRAOTHEwMv9idM/ENYDguCL3numsXelyRF14SUIds9HvfoJuxqekWkg4p77istszaCYoixQDGmPfy0pfSbb9cfFkEm1xHmlLxTicQk8SKWM0AWauF3myOmZ09l1zVse6I8cFCUfCIqAVjoK9g5s+OmD6sM9SSdIyKRnqZUJeUKj3IMqYcFq3IsbrQQ3vL3jnyAkmSlsfUhEDC7bBwpVxLMSiUDofuN6gNrVujnWDQKzzFO8c4UT88XkcYCcUo2uAAZQxZn8cZ6ZqwUKgzLdxqfd8P7u4ia7Wtal4f3d19dT8FqIa/HrH0KBgLIupPJuh8GYDbmPk9czikqTMUATiMiA4B8J8wycUX7fUF1iAa6SXADde83rEsAP8Rus4Iy7aOk1b6/zUwD/TjvzkudwZ8gMJLKiYp4cqrDsPZZx+Bn/98Gps27cJb37EVL3zRdmREaKF8fvM0nAP2RHtNiu7usttLmUQ0cfesVVY7Jglhal3Lu8bu7gE6azP0Zgskacs7H1DqXJsfhwK92dKj9rxkT5a0SsEzdMCBx+Jor+mg3ekYQ50aQz2zcycAIM2AdmdOQmURi4wF5EkfCeDFAH5ARN+zY28EsAbARQAOBPAvRPQ9Zn4WM99KRNIZagDVGYqITgfwJQApgI/aLlILjmiklwDzeWwO2R4uBoyi2aDX8KX1PF2Vpw31VVcfhlee9mTMzBjDeNdd63D6y5+MhIAXn/gzwHYHr9DjAi920DdecG+2jDU77rHS1tDHa1aJ6D83yZP64lNBqXnhe/vCsw451vp6hAFini5amFq3Hu1OB0mSoNftoshziKpe1mo3fVURS4gFZHd8A81i+59rOKa2MxQzXw/g+r2+qBFYzEa0mwB8AsBvwpS9XcrMFxLRRgBXATgYwJ0Ajmfm++1jyIUAngNgBsBLmPk7dq2TAJxtlz6PmS9frOteCHz1atfWzCt5dvzmhnBDhY6n4q7y2B9Kl2po2dFy7WorLsE5b36SM9CCmZkW3vymI/CXL/pppWhE1i5mdeFK7pgeuuxaBPcr/GlN/7McZe8elDHXZdpNP17yOYTskVAwSdaTZGV3ZoAiL7DPtDHOnakpZK02slYbRVGg1+0ia7WQtWrUpyKWBbEsfOHRRBp/CYCvMvM7bZXOG2Ca0z4bJt5zGAyV5QMAjrBG/S0ANsM89dxiSeP3L+K17xG2XPlaAPWC+zrOKoY65PGK9ybzQwW2did1Jdx1SUddPu2N181NCT//+XTtffz8LjPuhw9q9DP6BZI0sZ6nrjT09S/qQiSuHD24Zw25f/MDozq1BGtKEtN41Ub1Tqv+uTCN3e7N5mAG9plehyLP0Zvt2s/XetOzXQz6PWStVgx3jAmidscioIk0DkP4foqddjmAG2GM9LEAPsHMDOAmItpARA+1c7cw830AYA390QA+tVjXPl984ZN/M1TTWWOYR232+6wFMSztDpdVeuoxvs4rDzu01FUmJilh06ZduOuudZV9mzbt8gybjouHcV/vOt0PkTHcSUpIcp+5oT8Huc8k0XTEpPLZCENEvO/Qa67eZ4KsZUI7cg79d9DLsc/0OhuLbqG9puOSh1m7janpdRj0euisXVv5bCKWB8zRSC8qAtL4Q6wBBzP/goh+w047CFVy+EFDxpcd//Lx1wBoDkGMpNhZ4yVFGsPmD3oFBq0cMzvZVuql7nyhopsWK9KMjnDueedtxSte8WQv5DE11cd55231fiB0/FnT6PSYNpb+NRiet9bX8HQ4CkaSlB1UpFs4kDgtaGGIhD8aIe9arkvvk/MDhmkys6uPNDMe8vqN+2PjQ37TxsNTtNd00Fm7FkmS4r/u+CkAYP3G/Yd+hxFLgwKrV/R/0flFC0AabxoPz3MqEW0jom333nvvnl3sPPGnLykZPE16EQAqnq0br6WNJTZhVZaAl+2g/GTcMAhHWvcR1GXgAHDCC2/HJRffgE2bHgAR4+GbHsAHLrkRx7/gJx5rQifhgNKD7s3mXjjBu6+k7Hoe3rdZo14IqexD6IdN3GdcFzYp/M9de/z6PgDR0s6Np58kyFotdKbWYnrfDZhat94Z7vUb90fWalVi4RHLhdGdwleqp72onnQDafy/ieih1ot+KIB77HgTafxulOERGb8xPJct/bwUADZv3ryk31ZT6CJEHTvDo8QFBkGr1AkFDSj7/vlz5VgxbIYj7YpDajzpImccf9zteMHzf+JdS3hvdfeg91cqH+tae/XV/JrPS/dfFM40UM8nP/KY873tf77sTG8dMdDHnXFx5ViNj7z1jTYskyJrtdHudNCZmsL6jfvjnrvvQndmN4qiwI2fvRpP+fPjh64VsbhYzTHpRXMThpDGrwVwkn1/EoDPq/G/JIMnAfi1DYt8CcAziWg/ItoPwDPt2NiiyZsO4YxnWvWuxWi3OynaazJ0plq2w3fSSMWrnDP0oHVZeMh5DrxhoD5Z6BWqBMbf/aC0qyXsGr3uwA+nBN6wF0YJqHt/8ty/q6z3Z6e8F71Zwyr5X694H55/2kUjDTQA/NVbz0e7s48Jddj4dNZqozO1FlPr1qMztdaNRSw3CMytka+ViMX0pJtI4+8EcDURnQLgLgDH2X3Xw9DvtsNQ8E4GAGa+j4jOBXCznfd2SSKOK+rYHW47MMhmTtWgOVW43BjCdieteOC6gq8s9/bLyGuTkzlXDKGvfRHMr9Gy0AU1ddWO7jw1RjhJE9NjMfW7e+v1K++L4SGe5592UeO+YTj6f78E397yRbQ7HZtANP/Rp/fdgF2/3uGuN2KZwQQUq/PHcjHZHcNI40fVzGcAr2pY66MAPrpwV7d30I/Xc/0PHJZy+ywFnwusjZYUezjBfmUMyx6CJrShKxQ1RPVNrkPiybqKMUOCIikZEeX91dPe6uh5YXy65EEP3HnK+HZiY9vmM2ynaaWqEgCe+vwL5vT57g2e+IyjAQB33nYrslYL3ZndGPR7mN53A4o8R2ftWvzku7fgkYc/ftGvJaIBnAKDesroSkesOGzApy863ds+7oyL8fkPvxqAGJHhxRV7groWWhX6WL+sqOtMZehMZR6LY1h1Y1giXXbk9nWc9+za68rGC89gC8uiWoEoJeS+R33U8e/ao2vZU0h5OABMrVuPrNVGb7Zrw06RL728iJ50hEJooJOUcM0lZzQk1oTDq7Saa6r7wvWaxI7CsTCUIAbWeKlaurPwrkVfq8zTjIpet/RugQKw/Oumgpj5QP+wVIy3+zGoSokCVe2RpcTDDnkEHrjv/wEAet0HHfsjetDjgGikIxSOO+NiXHPJGW67Pt5aOMMcetV1cWid7PMTeomrugtFlQDV2duOtdO0UiI+6JUdsHVjVTneXK/you38uph2XRn4fFDyoYsRZeGl0pw5poDksYuc8acnzkWgbOGxfuP+Rr+jKLDhgAOX5RoiahBj0hFNaNJdDg10HYNiVNKwjEH7Blob9Drv3Ve5KxunShJOqv0AAA2NAjSHWo/reUXOnha1vvY6b7v0mAvPM9br6WSjDnkM+gWSgnHsyy6srLvUaHc6MbwxdkiikY6oh378zlq+wfJKrwPjqo91a+kwQM5od0oD7c0LBIFkv9NbtmEDKfwIr9d1BNdays6YV4WHgAID+Nofumt3+EMha+nPQWtoiH4GAMfvFjH+Qb/AAIVjkhR5WaW4p/HwiFWA6ElHaHz6otMbqGtliENQ1+mkLlQwLE4dijCF1XtevHYUN9qtZcIHOtzhNJZFtKhSUFIafc080Tq+npFX1ymaIsISKQrCALmTEpX7EL1ppw9tP892mlTi1BERDpwA/cjuiLCQQghtrI0QEHmGuhQUIq8KsKJ8F3jKLrSRJJXQQbiO510qrr6mq8maAk/fovDDDt5YXu/ph2gyzOF6TUU2RcLefbkfjqT8fMz9RD5yRBMSgFenJx3/VwzBcWdc7OtEFFpDuRQZ0poSMk9Qp9VhOpiUjIuyuMSIzYtGc6hJIck/0WzW67o5NVQ67cU3qeLp8Ib3qjPKTcY8uNamEnKdDNXc7yIv8LkP/p/atSNWO2y4Y9RrBSIa6RHQhlon6UKDFLIXgCqTQ8bccUXhjLIY5iaIx+1dQ4MBrSQBXXijWobuzRtSIl63tn7KqOh3OO84uI9ExdcDXnT4oxQR4cCr10jHcMccUVcObbbhxrV3CMBL3GnjaIyXEsYPCj7MOczjvzPOvarnLNV72hutsDbkB6aXq3OX1zboF6X4kQ6DDPHOw9BJyIXW11kUtvIwTT0aYKhiZ+49HQt2R8Q4IiYOIxpwzSVneOwFwKfAAQEPuk5gP4j7Oq2MOkGjlhxTxr2bKG+hR+yJM6m2WXV9/+rQpJsh6zTtC9fQ3VbcfRQ+q6TO+46IaMbqNdIx3DFH1NHthvGg6+CE65VY0Fwe8XUIQgsj1XKxK3Hg+vBM3Tkaz6+93iDWHYZ3ZJ6EcMw8X/Gu+f4KTxclIsJBtDtGvUaAiDYR0Q1EdBsR3UpEr7bjG4loCxHdbv/uZ8eJiN5HRNuJ6PtE9Di11kl2/u22D+uiIHrSQ6CrDgGocEbJl/arBwNWRyCGNFcecJ0qnvZE7Sw7Xj2XOyYv+cwjjWSNJvRcEoRN564La4Tni950xJzBBOQL4klPXO/VaKQbEHKlQ0McIjRoYXGKNpaA8sxrpUGrCbcmj7WpYnDQy9GbzSvXUremX649em54PcPEmXrdfKiOiTbUf3bKexvnRax20IJQ8Cax92o00kMQJtDKcb+opU6GVK8hRjoUL6oLl0j4oxK2UB6zobeV69et50rFa4y4DrF4VD7Vn1BfwzADre/TC+EE1ZVyrG6k6x8fC1kihmHOMekDiGib2r7Udm2qrkh0MCag92o00jUIVfA0SoNsDHVYJag1OLSovhZAaoojh0wP77x2XLqehFQ6j/ExW9V6Dj35JoOrf2yKnF3FYHhseJ3leXKPiSIVhsPabhU5Ry86Yjh4ztodv2LmzaMmhb1XTSOp+ql1VzNkfMERjfQ8MawQxM7wil963bziebvjAq96PvFZnbgMudjh+sNYHXVhlKb9o473aIpqvKmV1jNOePfQtSMiHBawLHwpe68uBCK7Yw6opdXNoSOLMBYqY0HoISxQ8aoYA/aHMc5JY0w7TMh5SbrA4IqMqDbilYrDmld43tDQZy3TmzFrNxfPLLWgf8Skw8akR71GrTKBvVejJ92AYXS6UQbaN1rSJqrUpqgzcHUFJKEWRtM1zTd2LH9Lg773uhmlYFOCJDHJzyQl9PJqJeVStMSKWGFgAvKqbO4eYOJ6ry6akSaijwI4BsA9zPz7dmwjgKsAHAzgTgDHM/P99tftQpgPYwbAS5j5O/aYkwCcbZc9j5kvX6xrHoXS2JQdUOaS8NKGOrGVd17sd0iYo96LrysxrzfMeu1HH3HO0Ou8deu5LlQhc2/deq53rsqPSQO1ryzGMRp6Rx5z/tBzR0SMQlLDegoxasYk9l5dTE/64wAuBvAJNfYGjCkXUaNa2tzEF67qOQMFiiChV8ZqE68gRcdq9Xm8gplKE4C0Uvatk4JN3vYoA90059FHnINbt55bYWuUn4H2xuE6zcjcaJwjFgTMoLzu/9vKx6LFpJn56wBC9/9YGA4i7N/nqfFPsMFNAISL+CxYLqI1zMJFXHTUCSiF2+HL219TSeiU5pTiXIiKap4U0ChWh3QQbyoW0dehmRZ7ikcfcY77MRilkqcNdCxUiVg4GCM96rUSsdSJQ4+LCGBsuIgawzQs3HhNMq3OMFWMWA3HWlBhayiPOWslyFppqcVcDDfQgkG/wO9tPrtx/1zxB3/05tE/TOopoam6MSJiT0DMSPv9ka+ViHFhd+w1F5GITiWibUS07d57792ri9Hc5oohDo1yrQermRp+y6o9uY5y3eoPgNMDqbmOUVoi88XhT34rRF7VF0wqnww0S+UPn/2OBT1/xCoGY9V60kvN7lg0LqKtKroUADZv3rxXLpyLISe++l3tnCGGMAxrjCqP1nOELeHJh6oqQx2LHlauvtCG+vFPfTtu/so5Tk5VEoRPePq5C3qeiAgNAs8pcbgSsdRGWriI70SVi3g6EV0Jkzj8tTXkXwJwvihSwXARz1qKCw2NplcVGAoMqTLqsvKu7Ayo9xmjKXHbMplYR78rEvaYHK6K0SbqyuNU+CRgjDzmj9+yUB+JQzTIEUsO60mvRiwmBe9TMF7wAUR0NwxLY2y5iBpN3nOTSJI7LoxHBzFjz0tWLaOcodbC/aFWdJJ4xlm6iGeWlyzr6rDH4U9+67zvPSJiLLGK2R2LZqSZ+S8ado0lF7EOdfoUc5HpnKtAvrdOTUMBze4Q4yye9JHHnI9vXvdG1ySgyDka5YgVjRjuiKjAb3c1WudCY1gir2RxlBWIjhOt2Bx6TLxnzTs+8pjzcfNXzkFRFHj8U9++p7cZETH2IC6Q9HrLfRnLgnFhd4wNPnbeqZXZxsAuAAAK4klEQVSxJvZEE0JjrtXvslYK0xA28cY17S400AAqBlrwhKefO69ri4iYSLDxpEe9ViKiJx1ADF7WTrxtHacOVeeavGbhNBvDXO2B6BrW1uzT8ezebD5U7yIm8iJWPmJMOiLAXApamqApcV6rraCaMGSEuBh4UXrVg34RBYkiVj0osjsiAODDbzkFAJCkpWGtCAfVKNg1iSCFXcI1qrQ8uLVkbm+2qiAXEbE6EXnSEShDGkXOQKs+tuzm1rS4cvO8Jq6qMi/3ZU4rnnPQtkrOExGx6sG8ahOH0Ug3QNPtdCGLGHFnUIdWHNYZ2DpvIPE40sOPj4hYfSCOFLxVjw+d/VLP4PZmB67kWaNiOC1PuU7bGYBXug1Uu44Ly8M7h9IJiS2mIiKAmDhc5fjQ2S/1tkvBoMJV+gENseea6kCgXgypUkUYqOEVBTvGx7C+hBERqw4xcbi6IZ28Q0iln92qiPTr5rFa3L9OfnQYdBhl4MWwo5GOiACiwNKqhxjDV57/MW88DIEIHD9aK9QVPme66jX7nVbCPol1fOyIiAiL6Emvbpzx9/VtEyuxYs3+CKDFjVyRitbhGCpTWnoIIrYUERGhYEX/VyNiWfgQvOxtlwFQTVWLameS2lfh/5VjgbIn4aCfq1ehupmUBnvQX52eQ0RECOKFa59FRB8lonuI6Idq7DFE9C0i+gER/TMRrVf7ziKi7UT0YyJ6lho/2o5ttz1bFwXRkx4BMdSA0fWo8JgbegsOU8cb1ilcS5gKMyQiImJB2R0fR7VJ9kcA/C0zf42IXgrgtQDOIaJHATgBwKMBPAzAV4jokfaY9wN4Bkxzkpttk+z/WKiLFEQjvQc46Y0f8rYvP//lAMoCl5EKeTVSpsK7Ni9Tafj80y5a4CuPiJhQLCBPmpm/TkQHB8O/C+Dr9v0WAF8CcA5Mk+wrmXkWwB1EtB3AE+287cz8MwCwDUuOBRCN9HLi5LMvrR0Xo60V9OYiwhR61tJ5BUA00BERHubsSR9ARNvU9qW2td4o/BDAc2G6RR2Hsp3fQQBuUvN0M+ywSfYRc7nA+SIa6QXEsDDIcWdcDAD49EWn+6yQOXCsIyJWO+YhsPQrZt68B6d4KYD3EdGbYdr5SQ16UzPsunzeovzHjUZ6ARGGQeogxvqKv38lTvzbDwAwhlsQPeiIiBosMruDmX8E00MVNub8p3ZXU5NsDBlfUER2xzJBDDRQGu6IiIgGLCC7ow5E9Bv2bwLgbAAftLuuBXACEa0hokMAHAbg2zB9Vw8jokOIqA2TXLx2L+6wERNjpJeK7rKciGGOiIh6EBauM4ttkv0tAL9LRHfbxth/QUQ/AfAjGI/4YwDAzLcCuBomIfhFAK9i5pyZBwBOh0kw3gbgajt3wTER4Q4iSrFEdJflwnFnXIxPvee05b6MiIjxxAJ2Cx/SJPvChvnvAPCOmvHrAVy/IBc1BBNhpGEoL0tCd1lO/MVrLlnuS4iIGFNEFbxxx0EYQXcholMBnAoAD3/4w5fuyiIiIhYdtIrLwifFSDfRYMoNw4W8FACI6F4i2g3gV0twbcuBA7By7w2I9zfpCO/vt/d2wZmZu750yy0vP2AOU1fc5zopRnoYDaYCZj6QiLbtIV9y7LGS7w2I9zfpWIz7Y+ajF3K9ScKksDuWjO4SERERMU6YCE+amQdEJHSXFMBHF4vuEhERETFOmAgjDewR3WUu9fqTipV8b0C8v0nHSr+/JQUxxwKKiIiIiHHFpMSkIyIiIlYlopGOiIiIGGOsOCM9qRofRLSJiG4gotuI6FYierUd30hEW4jodvt3PztORPQ+e5/fJ6LHqbVOsvNvJ6KTluueQhBRSkTfJaLr7PYhRLTVXudVlrkDK2Zzlb23rVqgvamV0XKDiDYQ0WeI6Ef2O/zDFfbd/bX9d/lDIvoUEXVW0vc31mDmFfOCYX78FMChANoA/h3Ao5b7uuZ47Q8F8Dj7fh2AnwB4FIB3AXiDHX8DgAvs++cA+AJMoc+TAGy14xsB/Mz+3c++32+5789e22sA/BOA6+z21QBOsO8/COCV9v1pAD5o358A4Cr7/lH2O10D4BD7XafLfV/22i4H8Ff2fRvAhpXy3cFU/N4BYB/1vb1kJX1/4/xaaZ600/hg5h4A0fgYezDzL5j5O/b9ThhlrYNgrl/amV8O4Hn2/bEAPsEGNwHYQEQPBfAsAFuY+T5mvh+mFdCyFwIQ0W/BaPR+xG4TgKcB+IydEt6b3PNnABxl57tWRsx8BwDdymjZQKZp6f8EcBkAMHOPmXdghXx3FhmAfYgoAzAF4BdYId/fuGOlGek6jY+DGuaOLezj4eEAtgJ4CDP/AjCGHMBv2GlN9zqun8F7AbwOgOhJ7g9gBxvJR8C/TncPdv+v7fxxvbdDAdwL4GM2nPMRIlqLFfLdMfN/Avh7AHfBGOdfA7gFK+f7G2usNCM9UuNj3EFE0wCuAXAmMz8wbGrNGA8ZXzYQ0TEA7mHmW/RwzVQesW/s7s0iA/A4AB9g5sMB7IYJbzRhou7PxtKPhQlRPAzAWgDPrpk6qd/fWGOlGel5aXyMG4ioBWOgr2Dmz9rh/7aPwrB/77HjTfc6jp/BkQCeS0R3woSgngbjWW+wj8+Af53uHuz+fQHch/G8N8Bc193MvNVufwbGaK+E7w4Ang7gDma+l5n7AD4L4I+wcr6/scZKM9ITq/FhY3aXAbiNmd+jdl0LQLL8J8F0M5bxv7RMgScB+LV9pP4SgGcS0X7WA3qmHVs2MPNZzPxbzHwwzHfyr8x8IoAbALzATgvvTe75BXY+o7mV0bKCmX8J4OdE9Lt26CgYrfOJ/+4s7gLwJCKasv9O5f5WxPc39ljuzOVCv2Ay5z+ByRy/abmvZx7X/ccwj37fB/A9+3oOTCzvqwBut3832vkE063mpwB+AGCzWuulMEmZ7QBOXu57C+7zKSjZHYfC/CfdDuDTANbY8Y7d3m73H6qOf5O95x8DePZy34+6rscC2Ga/v/8Lw85YMd8dgLfBtJb6IYBPwjA0Vsz3N86vWBYeERERMcZYaeGOiIiIiBWFaKQjIiIixhjRSEdERESMMaKRjoiIiBhjRCMdERERMcaIRjpi0UFG4e8OItpot/ez25Uu0kS0DxF9jYjSeax/OhGdvJDXHBExLogUvIglARG9DsDvMPOpRPQhAHcy89/VzHsVgIyZL5zH2lMAvsmmJDsiYkUhetIRS4V/hKlaOxOmcOcfGuadCFu5RkRPsV711UT0EyJ6JxGdSETfJqIfENEjAICZZwDcSURRUS1ixSEa6YglARvNh9fCGOsz2UjJerCl/Icy851q+DEAXg3gDwC8GMAjmfmJMJKnZ6h52wD8yeJcfUTE8iEa6YilxLNhpC5/v2H/AQB2BGM3s9HanoUpJ/6yHf8BgIPVvHtgFNoiIlYUopGOWBIQ0WMBPAOmE8lfizpcgAdhdB80ZtX7Qm0XMBKhgo49PiJiRSEa6YhFh1VO+wBMmOMuAO+GEZH3wKYbSUpEoaGeCx4JI/4TEbGiEI10xFLgZQDuYuYtdvsSAP+DiJ5cM/fLMInF+eJIAF/Zw+uLiBhbRApexFiBiA4H8BpmfvFiHhMRMSmInnTEWIGZvwvghvkUs8AkHM9ZpEuKiFhWRE86IiIiYowRPemIiIiIMUY00hERERFjjGikIyIiIsYY0UhHREREjDGikY6IiIgYY/x/Gbo/mrqESg8AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Plot Spring Creek\n",
-    "ax2 = map_fig.add_subplot(222)\n",
-    "ax2.xaxis.set_visible(False)\n",
-    "imshow_grid(rmg_sc, z_sc,plot_name='Spring Creek',var_name = 'Elevation', var_units = 'm', grid_units = ('m','m'), \n",
-    "            cmap = 'terrain', limits = (1875, 2615),color_for_closed=\"white\")  # plot the DEM\n",
-    "ax2.set_facecolor(\"white\")\n",
-    "plt.plot(rmg_sc.node_x[outlet_node_to_sample_sc],rmg_sc.node_y[outlet_node_to_sample_sc],'ro')\n",
-    "plt.plot(rmg_sc.node_x[midstream_node_to_sample_sc],rmg_sc.node_y[midstream_node_to_sample_sc],'go')\n",
-    "plt.plot(rmg_sc.node_x[upstream_node_to_sample_sc],rmg_sc.node_y[upstream_node_to_sample_sc],'bo')\n",
     "\n",
-    "# KRB note: Add legend."
+    "# Set up the figure.\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(6, 6))\n",
+    "ax.xaxis.set_visible(False)\n",
+    "\n",
+    "# Plot the DEM.\n",
+    "imshow_grid(rmg_sc, z_sc, plot_name='Spring Creek', var_name='Elevation', var_units='m', grid_units=('m', 'm'), \n",
+    "            cmap='terrain', limits=(1875, 2615), color_for_closed='white')\n",
+    "ax.set_facecolor(\"white\")\n",
+    "\n",
+    "# Plot the sample nodes.\n",
+    "ax.plot(rmg_sc.node_x[outlet_node_to_sample_sc], rmg_sc.node_y[outlet_node_to_sample_sc], 'ro', label='outlet')\n",
+    "ax.plot(rmg_sc.node_x[midstream_node_to_sample_sc], rmg_sc.node_y[midstream_node_to_sample_sc], 'go', label='midstream')\n",
+    "ax.plot(rmg_sc.node_x[upstream_node_to_sample_sc], rmg_sc.node_y[upstream_node_to_sample_sc], 'bo', label='upstream')\n",
+    "\n",
+    "_ = ax.legend(loc='lower right')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__________________\n",
-    "# 4.0. Make Model Decisions "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "<hr>\n",
+    "\n",
+    "# 4.0. Make Model Decisions \n",
+    "\n",
     "We used the following runoff categories for this exercise, which can be changed by the user: \n",
     "  * `Base` has an intensity of 5.0 mm/hr, with a duration of 2 hr.\n",
     "  * `HigherIntensity` has an intensity of 10.0 mm/hr, with a duration of 2 hr.\n",
@@ -592,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,48 +505,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_save = 1                   # 1: save image; 0: don't save, this is for animation\n",
-    "hours = 8                        #hours of model run time\n",
-    "Number_frames = 6                    # number of frames to plot\n",
-    "n = 0.03                            # Manning's roughness coefficient, (s/m^(1/3))\n",
-    "Base_runoff_rate = 10               # Base runoff rate (mm/h)\n",
-    "HigherIntesity_runoff_rate = 20     # High intensity runoff rate (mm/h)\n",
-    "Storm_duration = 5                  # Storm duration (hours)\n",
-    "dt = 600                             # time step for KinwaveImplicitOverlandFlow, (s) [i.e., 10 minutes]"
+    "image_save = 1                  # 1: save image; 0: don't save\n",
+    "hours = 8                       # hours of model run time\n",
+    "Number_frames = 6               # number of frames to plot\n",
+    "n = 0.03                        # Manning's roughness coefficient, (s/m^(1/3))\n",
+    "Base_runoff_rate = 10           # Base runoff rate (mm/h)\n",
+    "HigherIntesity_runoff_rate = 20 # High intensity runoff rate (mm/h)\n",
+    "Storm_duration = 5              # Storm duration (hours)\n",
+    "dt = 600                        # time step for `KinwaveImplicitOverlandFlow`, (s) [i.e., 10 minutes]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "______________________\n",
+    "<hr>\n",
+    "\n",
     "## 5.0  Model Computations\n",
     "\n",
     "### 5.1. Initialize model run time and output variables used for plotting and animation \n",
     "\n",
-    "The cell below is designed to set up the model with the decisions made in the cell above. Do not change it unless necessary."
+    "The cell below is designed to set up the model with the decisions made in the cell above. Do not modify the cell unless necessary."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Convert time\n",
-    "elapsed_time = 1.0   #seconds\n",
-    "model_run_time=hours*3600 #converted to seconds\n",
+    "# Convert time.\n",
+    "elapsed_time = 1.0             # seconds\n",
+    "model_run_time = hours * 3600  # converted to seconds\n",
     "\n",
+    "# Set up the number of frames to be recorded for creating the animation.\n",
+    "ani_inc = np.arange(0, hours, np.true_divide(hours, Number_frames))  # list of timesteps for animation\n",
+    "snap = 0   # first snapshot for animation\n",
     "\n",
-    "# Setting up the number of frames to be recorded for creating the animation\n",
-    "ani_inc=np.arange(0, hours, np.true_divide(hours,Number_frames)) #list of timesteps for animation\n",
-    "snap=0   #first snapshot for animation\n",
-    "\n",
-    "## Lists for saving data\n",
+    "# Create lists for saving data.\n",
     "discharge_at_outlet = []\n",
     "discharge_upstream = []\n",
     "discharge_midstream = []\n",
@@ -662,44 +557,47 @@
     "    outlet_node_to_sample = outlet_node_to_sample_sq\n",
     "    midstream_node_to_sample = midstream_node_to_sample_sq\n",
     "    upstream_node_to_sample = upstream_node_to_sample_sq\n",
-    "    ### Reading in the DEM given the filename from above\n",
+    "    \n",
+    "    # Read in the DEM given the filename from above.\n",
     "    (rmg, z) = read_esri_ascii(watershed_dem, name='topographic__elevation')\n",
-    "    ## Setting initial fields...\n",
+    "    \n",
+    "    # Set initial fields.\n",
     "    rmg['node']['surface_water__discharge'] = np.zeros(rmg.number_of_nodes)\n",
-    "    rmg_sq.set_watershed_boundary_condition_outlet_id(outlet_node_to_sample_sq, z_sq,-9999.)\n",
+    "    rmg_sq.set_watershed_boundary_condition_outlet_id(outlet_node_to_sample_sq, z_sq, -9999.)\n",
     "\n",
     "else:\n",
     "    watershed_dem = 'SpringCreek_DEM.asc'\n",
     "    outlet_node_to_sample = outlet_node_to_sample_sc\n",
     "    midstream_node_to_sample = midstream_node_to_sample_sc\n",
     "    upstream_node_to_sample = upstream_node_to_sample_sc\n",
-    "    ### Reading in the DEM given the filename from above\n",
+    "    \n",
+    "    # Read in the DEM given the filename from above.\n",
     "    (rmg, z) = read_esri_ascii(watershed_dem, name='topographic__elevation')\n",
-    "    ## Setting initial fields...\n",
+    "    \n",
+    "    # Set initial fields.\n",
     "    rmg['node']['surface_water__discharge'] = np.zeros(rmg.number_of_nodes)\n",
-    "    ## Set boundary coditions on the grid\n",
+    "    \n",
+    "    # Set boundary coditions on the grid.\n",
     "    rmg.set_watershed_boundary_condition(z)\n",
     "\n",
-    "\n",
-    "## instantiate OverlandFlow object\n",
+    "# Instantiate OverlandFlow object.\n",
     "if routing_method == 'OverlandFlow':\n",
-    "    \n",
-    "    of = OverlandFlow(rmg, alpha=0.15, mannings_n = n, steep_slopes = True) \n",
+    "    of = OverlandFlow(rmg, alpha=0.15, mannings_n=n, steep_slopes=True) \n",
     "else: \n",
-    "    kw = KinwaveImplicitOverlandFlow(rmg, runoff_rate = 0.0, roughness = n, depth_exp = 5/3)\n",
+    "    kw = KinwaveImplicitOverlandFlow(rmg, runoff_rate=0.0, roughness=n, depth_exp=5 / 3)\n",
     "    \n",
-    "## Assign storm conditions based on flag in Code Block 2\n",
+    "# Assign storm conditions based on flag in code cell above.\n",
     "if storm_flag == 'Base':\n",
     "    runoff_mmhr = Base_runoff_rate\n",
-    "    runoff_ms = runoff_mmhr * (2.77778 * 10 ** -7)\n",
+    "    runoff_ms = runoff_mmhr * (2.77778 * 10**-7)\n",
     "    storm_duration = Storm_duration * 3600.\n",
     "elif storm_flag == 'HigherIntensity':\n",
     "    runoff_mmhr = HigherIntesity_runoff_rate\n",
-    "    runoff_ms = runoff_mmhr * (2.77778 * 10 ** -7)\n",
+    "    runoff_ms = runoff_mmhr * (2.77778 * 10**-7)\n",
     "    storm_duration = Storm_duration * 3600.\n",
     "elif storm_flag == 'LongerDuration':\n",
     "    runoff_mmhr = Base_runoff_rate\n",
-    "    runoff_ms = runoff_mmhr * (2.77778 * 10 ** -7)\n",
+    "    runoff_ms = runoff_mmhr * (2.77778 * 10**-7)\n",
     "    storm_duration = Storm_duration * 2 * 3600."
    ]
   },
@@ -709,50 +607,16 @@
    "source": [
     "### 5.2. Run Overland Flow Model \n",
     "\n",
-    "For each timestep, discharge is calculated at each node.  Using the depth slope product, shear stress is calculated at every node.  Outputs for each node include: water depth, discharge and shear stress values through time at every point in the input grid.  Read more on the [Landlab component description](https://landlab.readthedocs.io/en/release/landlab.components.overland_flow.html) by Jordan Adams. "
+    "For each timestep, discharge is calculated at each node.  Using the depth slope product, shear stress is calculated at every node.  Outputs for each node include: water depth, discharge and shear stress values through time at every point in the input grid.  Read more on the [Landlab component description](https://landlab.readthedocs.io/en/release/landlab.components.overland_flow.html) by Jordan Adams.\n",
+    "\n",
+    "This make take several minutes to run. The elapsed time (the simulated time, not run time) will print immediately below the code cell."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "elapsed time = 0.0 hours\n",
-      "elapsed time = 1.33 hours\n",
-      "elapsed time = 2.67 hours\n",
-      "elapsed time = 4.0 hours\n",
-      "elapsed time = 5.33 hours\n",
-      "elapsed time = 6.67 hours\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div align=\"middle\"> <video width=\"80%\" controls loop><source src=\"animation.mp4\" type=\"video/mp4\"> </video></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASgAAAEXCAYAAAAeK9lhAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAHeVJREFUeJzt3X+8XHV95/HX+yYBAipJRNiURCESFboWyGKMUn8s2BCoNWwXdsODyhWzpo8tdEX7qEJZG5V2i7sVWlalZvFHYKmQoi4pssYYkD5WS0gQDD9CzBUQsiCJm4AtIIbcz/5xvpOcezN3Zu7NnDlnZt7Px2MeM/Od75n5njv3vu/3fM+PryICM7MqGii7AWZmY3FAmVllOaDMrLIcUGZWWQ4oM6ssB5SZVZYDyipJUkg6p+x2WLkcULaXpJmSVkraIemXkh6W9K4my0jSJZIekfSSpKclXZl7/aspbEbfni9+jazbTS67AVYNkqYB3wf+D/DbwA5gDrC9yaKfBd4L/DHwAHA4MDP3+oeBS0ct833gHw681e0n6aCI+FXZ7bAkInzzDeC/AN8f5zJvBHYDx49jmVOBAN7epF4Ay4C/A54HHgV+b1SdNwPfBV4EdgJfBQ7Pvf5V4LZRy3wSeHB0HeDjwDZgeyr/XWBT7r3vAo4q+3vqt5s38azmbGC9pJslbZd0v6SLJanBMovJgmORpEclPZ42EY9ssMyHgIci4gcttOlPgVuBE4GbgS9Leh2ApEOBbwP/DMwH/g3wduDLLbzvaO8CfgNYBJwu6V8ANwErgeOBdwI3TOB97QB5E89q5gB/AFwNXAmcBPz39NrnGizzOmAJ8AGyXs9fAn8v6W0RMZyvLOlw4FzgT1ps0w0R8T/Tsp8g21x8B/BT4HzgFcD7I+KfUp1lwJ2SjouIoRY/A+CXwAcj4qX0PvOAKcAtEfHTVOfBcbyftYkDymoGgI0RcVl6fp+kucBFjB1QA8DBZCHxYwBJ7we2AG8B1o+q/3vAJFrvjWyqPYiIlyXtAGq9s+OBTbVwSn4ADAMnAOMJqAdr4ZT8iGzT8UFJ30mPb4mIHeN4T2sDb+JZzdPAw6PKNgOvbbLMy7VwSrYCL4+x3IeAr0fEzhbbtHvU82Df76zS83pq5cOpXt6UOvVH7FGMiD3AwnTbBCwFtko6sbVmW7s4oKzm+2SD3nlvINucarTMZEmvz5XNIeuZj1hO0nyysaT/ceBNBbIwPVHSK3Nlbyf7nd6cnu9g5B5FyDZdm4rMP0bEp8h6g08B//7Ammzj5YCymquBBZIul3ScpHOB/wR8vlZB0l9IWpdb5rvAD8kGr0+WdDLZIPV6YOOo919G1ru6q03tvZGs53O9pDdLeifwReAbufGnO4CTJX0wrdPHyPYiNiRpgaT/LOktkl4LvA+Yzf49TCuYA8oAiIgNZHvy/h3ZgPCfA58AvpCrNhN4fW6ZYbJjoLaTHde0hmxX/eL8AHnq5SwBrou0D78N7X0BOAN4FXAP2d6+fwQ+mKuzBvhUWpd7gWNGrc9YniMLstvIQvWzwBW1AXvrHLXp98XMrO3cgzKzynJAmVllOaDMrLIcUGZWWT15JLkkj/ybVcfPI+I1E1nQPSgzK1qjg30bckCZWWU5oMysshxQZlZZDigzqywHlJlVlgPKzCqrJ4+Dst714u79D3GbOqXRZdOtmzmgrPLqhdLo1x1SvckBZZXWLJzq1XNY9Q6PQVlltRpO7VrOqscBZT3pxd3hoOoBDigrzYIr79obJPVu7VD0+1uxPAZlpahCQHhwvfrcgzKzynJAWcdVofdk3cEBZR3lcLLx8BiUteRAx2uqGkxjtctjU9VQWA9K0hsl3Z+7/ULSJZJmSForaWu6n57qS9I1koYkbZI0L/deg6n+VkmDRbXZ6jvQcKlqODVSdJtbff+/f+Bnhbaj6goLqIjYEhEnRcRJwL8CXgC+CVwKrIuIucC69BzgTGBuui0DrgWQNANYDrwVmA8sr4WadVY3Bs2BaPfhCC/uDg456aKG71l7rfbZ73nTUX33c8/r1BjU6cBPIuKnwGJgZSpfSTbdNqn8+sjcDUyTNJNseuu1EbEzInYBa4FFHWp33+vnP452qv0cd2343Iiyesdm1fuZT+R7GCtgu+k77VRALQG+lh4fFRFPA6T7I1P50cCTuWW2pbKxykeQtEzSRkkb29z2vuSDGfcZz/mARR902szyNT/e7zNbDcEqKnyQXNJBwPuAy5pVrVMWDcpHFkSsAFakz+yOn34BGv3i1Rv4rdWf/paLR/x3b/T+/TiAXJU/6Fo7at/BgbSrG06w7kQP6kzghxHxTHr+TNp0I91vT+XbgNm55WYBTzUo73vt/E/dSjiN/lwrTxHjY1XUiYA6j32bdwCrgdqeuEHg1lz5BWlv3gLgubQJuAZYKGl6GhxfmMpsnOp1/Q/0/VpR1f/ONlIVz1MsdBNP0qHAbwG/nyu+ElglaSnwBHBuKr8dOAsYItvjdyFAROyUdAWwIdX7dETsLLLdva6o/7wOot5RlU15RVQnLdulX8agqvSfLq/RWJd1lzaF1L0RccpEFvSpLl2qyn/wVW6bdRcHVBfqhgDohjZac2WPSTmgrDAOKTtQDqgu021/9KOP27HuVNbvnQPKCtdtoWrV4YCyjnBIdb8yvkMHlJm1rNMh5YAys8pyQJl1oeEIdvzipbKbUThf8reLeBzHhoeDACYNiCNeeTDDEQgREUhiz3BQOzuk9tty0OTu7Yc4oMwqLAIigoGB7DCN2j2ABEpXI5Ky+8mTRP0rFO3/ngB7IvYm2ZQKBpkDyqxC9gwHw8P7ekAHTR7YGz7tIu0LtIEUZrtfHm7rZ7SLA8qsAvYMB8MRTJk0wKSBzh/UOmXyALv3DDM8DFMmi4E2h+JEOaDMShYBA1IpwZQ3ZdIATILnX3o5jWXB4YdO2a9eJy/FUr2NTrM+MRz7Nucq0mEB4LCDJ/OqqVP2v6520snTltyD6hLeg9d7hFCVuwgV+JWr8o/HEodTb6pSr6meaYdNIaLcAXQHVMU5nKxMUnZow+495YSUA8qsBGVeaXu8Y0iTBlTa5l6hASVpmqRbJD0iabOkt0maIWmtpK3pfnqqK0nXSBqStEnSvNz7DKb6WyUNjv2JZjaWqVO0N5zGG1IDA9lR6p2+rlfRPai/Br4dEW8CTgQ2A5cC6yJiLrAuPYds/ry56bYMuBZA0gxgOfBWYD6wvBZqZtaaesEynrCZNFDOYRCF7cWT9CrgncAHACLiV8CvJC0G3p2qrQS+B3wcWAxcH9kx+Hen3tfMVHdtbaopSWuBRYyca68nefyp9+xJhxWUfcxTTdWvdFpkD2oOsAP4iqT7JF0n6TDgqDQhJ+n+yFT/aODJ3PLbUtlY5SNIWiZpo6SN7V8Vs/YQnQun6W+5GKh+CDVSZEBNBuYB10bEycDz7Nucq6feTzEalI8siFgREadMdP4ts6LVDsrslF/e//muDicoNqC2AdsiYn16fgtZYD2TNt1I99tz9Wfnlp8FPNWgvKd58673DAxoxNUIipIfDO92hQVURPwMeFLSG1PR6cDDwGqgtiduELg1PV4NXJD25i0AnkubgGuAhZKmp8HxhanMrPLyp7N0Qq8EU03Rp7r8IXCjpIOAR4ELyUJxlaSlwBPAuanu7cBZwBDwQqpLROyUdAWwIdX7dG3AvBe559RbBrKLNnVEr4UTgKLMI8YKIqnrVsrBZK3qwiC6d6Jjwz5ZuGQOJhuPLgynA+JTXcxa0IMbGl3BAVUi9566R9WvPNCrHFBmXaTf/qk5oErSb79oZhPhgCpJvw12Wnv02++NA8qsS/RbOIEDyqwr9GM4gQPKzCrMAWVmleWAMrPKckCZWWU5oMysshxQZlZZDigzqywHlFnF9esxUODrQZlVVj8HU417UGYV8dHVD++d8MDhlHEPyqwkDqHmCu1BSXpc0gOS7q9NqClphqS1kram++mpXJKukTQkaZOkebn3GUz1t0oaHOvzuokvt2LWXCc28f51RJyUu2j6pcC6iJgLrGPfZJ5nAnPTbRlwLWSBBiwH3grMB5bXQs3MelsZY1CLgZXp8Urg7Fz59ZG5G5iWJvY8A1gbETsjYhewFljU6Ua3m7v3Zs0VHVABfEfSvZKWpbKj0oScpPsjU/nRwJO5ZbelsrHKR5C0TNLG2qakmXW/ogfJT42IpyQdCayV9EiDuvW6FNGgfGRBxApgBXTPvHhTp8hjUX3KPejWFNqDioin0v124JtkY0jPpE030v32VH0bMDu3+CzgqQblZl3J4dS6wgJK0mGSXll7DCwEHgRWA7U9cYPArenxauCCtDdvAfBc2gRcAyyUND0Nji9MZWbW44rcxDsK+KayCcUmA38bEd+WtAFYJWkp8ARwbqp/O3AWMAS8AFwIEBE7JV0BbEj1Ph0ROwtsd0d5M6+/uPc0PooenDK1W8agahxQ/aNPA+re3GFG4+JTXSrApzb0B3/H4+eAMusAh9PEOKDMrLJ8srBZgdxzOjDuQZkVxOF04BxQZlZZDiizArj31B4OqIr47uYdZTfBrHIcUBVx6nFHlN0EaxP3ntrHAVUBPpLcrD4HlFkbuffUXg6okrn31DscTu3ngCqRw8msMQeUmVVW01NdJB0CvBd4B/BrwItkF577VkQ8VGzzzKrNm3XFahhQkj4J/A7wPWA92eV5DwHeAFyZwuuPImJTsc00s37UrAe1ISI+OcZrV6XJEF7b3iaZVZ97Tp3RMKAi4ltNXt/OvkkPzPqCw6lzWrrciqRTgMuB16VlBERE/EaBbTOrHIdTZ7W6F+9G4CvAvyUbk3pvum9K0iRJ90m6LT0/VtJ6SVsl3SzpoFR+cHo+lF4/Jvcel6XyLZLOaH31zNrH4dR5rQbUjohYHRGPRcRPa7cWl/0wsDn3/DPA1RExF9gFLE3lS4FdEXEccHWqh6QTgCXAr5NNef4FSZNa/OxK8y+8WWOtBtRySddJOk/S79ZuzRaSNAv4beC69FzAacAtqcpK4Oz0eHF6Tnr99FR/MXBTRLwUEY+RTUs1v8V2V54nTOgO/o7K0WpAXQicRNaD+R32beY181fAx4Dh9PzVwLMR8XJ6vg04Oj0+GngSIL3+XKq/t7zOMntJWiZpo6SNLa5TpSz63A/KboKNweFUnlavSX5iRLx5PG8s6b3A9oi4V9K7a8V1qkaT1xots68gYgWwIn12151DctdHTmXqR3z6S9U4nMrVakDdLemEiHh4HO99KvA+SWeRHdz5KrIe1TRJk1MvaRbwVKq/DZgNbJM0GTgc2Jkrr8kvY9ZWDqRqaXUT7zeB+9NetE2SHpDU8OjxiLgsImZFxDFkg9x3RMT5wJ3AOanaIHBrerw6PSe9fkdk0x6vBpakvXzHAnOBe1psd9fxH4jZPq32oBa18TM/Dtwk6c+A+4AvpfIvATdIGiLrOS0BiIiHJK0CHgZeBi6KiD1tbE/lTJ0ib+p1mP8xVJOyTsoYL0qviIh/bvgGLdTptG4cgxrNAdU5DqfC3RsRp0xkwWabeLdK+qykd0o6rFYoaY6kpZLW0N7eleFw6iSHU7U1Oxfv9DTI/fvAqZKmk21mbQG+BQxGxM+Kb6ZZ+zmcqq/hJl636uZNPPeeOscB1TGFbeJZh/mPpjP8c+4ODijrOw6n7tEwoCTdnr+qgJlZJzXrQX0V+I6kyyVN6UB7zMz2arYXb5WkbwF/CmyUdAP7TvwlIq4quH1m1sdaOZJ8N/A8cDDwSnIBZWZWpGazuiwCriI7H25eRLzQkVaZmdG8B3U5cK7nvzOzMjQbg3pHpxpiZjaaj4OyvuJjoLqLA6pifKpLsfzz7S4OKOs7Dqnu4YCqEP/hdI5/1t3BAWVmleWAsr7lXlT1OaAqxHuYzEYqLKAkHSLpHkk/kvSQpE+l8mMlrZe0VdLNkg5K5Qen50Pp9WNy73VZKt8i6Yyi2mz9x72oaiuyB/UScFpEnEialVjSAuAzwNURMRfYBSxN9ZcCuyLiOODqVA9JJ5DN8PLrZNc//4KkSQW22/qMQ6q6CguoyNRme5mSbgGcBtySylcCZ6fHi9Nz0uunS1IqvykiXoqIx4AhYH5R7bb+5JCqpkLHoCRNknQ/sB1YC/wEeDbNKgzZrMFHp8dHA08CpNefA16dL6+zTP6zlknaKGljEetivc8hVT2FBlRE7ImIk8imK58PHF+vWrqvN0IcDcpHf9aKiDhlohdnrwoPlJfLIVUtHdmLFxHPAt8DFgDTJNVOUp4FPJUebwNmA6TXDyebYXhveZ1lepJDqlwOqeooci/eayRNS4+nAu8BNgN3AuekaoPArenx6vSc9Podkc2JtRpYkvbyHQvMBe4pqt1mVh2tXFFzomYCK9MetwFgVUTcJulh4CZJfwbcB3wp1f8ScIOkIbKe0xKAiHhI0irgYbJJQy+KiD0Ftrt0/g9evhd3h3uyFeCJOyvG4VQtDqm28MSdZkXwP4xyOaAqxH8M1eTvpTwOKDOrLAdURfi/tNn+HFAlyQeSw8msviIPM7AmHExmjbkHZdaEDzUojwPKrAGHU7kcUGZWWQ4oM6ssB1QJPDhu1hoHVIc5nLqLv69yOaDMrLIcUB3k/8Zm4+OA6hCHk9n4OaDMrLIcUB3g3pPZxDigzKyyipw0YbakOyVtTlOffziVz5C0Nk19vlbS9FQuSdekKc43SZqXe6/BVH+rpMGxPrMqXtwdI25mNjFF9qBeBv4oIo4nm27qojSN+aXAujT1+br0HOBMshlb5gLLgGshCzRgOfBWsrn1ltdCrWocSGbtVeTU509HxA/T438im3LqaEZOcT566vPr05Tpd5PNnzcTOANYGxE7I2IX2QzFi4pq90Q4mMyK0ZHrQUk6BjgZWA8cFRFPQxZiko5M1caa4rylqc/L4FAyK1bhg+SSXgF8HbgkIn7RqGqdspanPpe0TNJGSRsn1tLx86U4zIpVaEBJmkIWTjdGxDdS8TNp0410vz2VjzXFeUtTn0fEiog4ZaLzb1n3mDpFI26t1ht9m/6Wi1v6PPeUy1PkXjyRzRa8OSKuyr2Un+J89NTnF6S9eQuA59Km4BpgoaTpaXB8YSqzPlQvkPJlrQRXzS/v/3xb22btV+QY1KnA+4EHJN2fyv4EuBJYJWkp8ARwbnrtduAsYAh4AbgQICJ2SroC2JDqfToidhbYbutCE93cnjpF7iFVmKc+nwD/QndOJ8f5mn2vHnOcME993m6LvnD3fgdb+nCCznIgmKedquPOR/4fC14/Y0SZg6n3jbW556AsjzfxxuBAKleZoVD77h1MbTPhTTz3oKxSqhAKVWiDZTwGZWaV5YCq455Hny27CWaGA6qu+XOmuZtvVgEOqAYcUp3nnROW54BqwiFlVh4HlFWK/yFYngOqiTOvXV92E8z6lg/UbMJjIp3nXlTP8bl4RXA4mZXLR5KPweHUee452WjuQZlZZTmg6nDvqfPce7J6vIlnpXEoWTPuQVkpHE7WCgeUdZzDyVpV5KwuX5a0XdKDubIZktZK2prup6dySbpG0pCkTZLm5ZYZTPW3Shqs91nWmmbTMNWrW8Rnm7WqyB7UV9l/ivJLgXURMRdYl54DnAnMTbdlwLWQBRqwHHgrMB9YXgs1G59WgqFeiBxooDiU7EAUFlAR8Q/A6OmhFgMr0+OVwNm58usjczcwLU3qeQawNiJ2RsQuYC37h54VzAFjZen0GNRRaTJO0v2Rqfxo4MlcvW2pbKxyG4d2BIxDyspQlUHyer/90aB8/zeQlknaKGljW1tme403pBxqdqA6HVDPpE030v32VL4NmJ2rNwt4qkH5fiJiRUScMtGTEq01Y4VOs0F3s4nodECtBmp74gaBW3PlF6S9eQuA59Im4BpgoaTpaXB8YSqzFhURFA4j65TCjiSX9DXg3cARkraR7Y27ElglaSnwBHBuqn47cBYwBLwAXAgQETslXQFsSPU+HRGjB95tDA4O63a+HlQd3XAuXr1ZcB1IVlG+HlS/yG9StfN4JbMqckCNUuXeU70QcjBZL3NAdYlGQeSQsl7lgOoCDiDrVw6onCpv3pn1IweUmVWWA8rMKssBlVR1887jT9bPHFDA8jU/LrsJZlaHjySnur0ncA/KesKEjyT3rC45o8OgysFl1g8cULiXYlZVHoNqwMFlVi73oJrIh5Q3+cw6ywE1AZ0aq3IPzvqdA2ocGl3uFtobVA4nM49BdYwvjWs2fu5BtVGrk2NC1tuq1/NyiJnt4x5USXw1TLPmuiagJC2StEXSkKRLmy9hZt2uKwJK0iTg88CZwAnAeZJOKLdV7eVelNn+uiKggPnAUEQ8GhG/Am4CFpfcprZzSJmN1C0BdTTwZO75tlS2l6c+N+s93bIXr17XYsRBRxGxAlgBIGkH8Dzw8+KbVooj6N11A69ftxu9fq+b6Bt1S0BtA2bnns8CnhqrckS8RtLGiV7ioep6ed3A69ft2rl+3bKJtwGYK+lYSQcBS4DVJbfJzArWFT2oiHhZ0sXAGmAS8OWIeKjkZplZwboioAAi4nbg9nEssqKotlRAL68beP26XdvWrycv+WtmvaFbxqDMrA85oMyssnouoLr1nD1JsyXdKWmzpIckfTiVz5C0VtLWdD89lUvSNWk9N0mal3uvwVR/q6TBstZpNEmTJN0n6bb0/FhJ61M7b057aJF0cHo+lF4/Jvcel6XyLZLOKGdN9idpmqRbJD2SvsO39dh395H0e/mgpK9JOqQj319E9MyNbA/fT4A5wEHAj4ATym5Xi22fCcxLj18J/JjsvMP/Clyayi8FPpMenwX8b7KDWBcA61P5DODRdD89PZ5e9vqltn0U+FvgtvR8FbAkPf4b4D+mx38A/E16vAS4OT0+IX2nBwPHpu96Utnrldq2EvgP6fFBwLRe+e7Iztp4DJia+94+0Invr/Qvts0/yLcBa3LPLwMuK7tdE1yXW4HfArYAM1PZTGBLevxF4Lxc/S3p9fOAL+bKR9QrcX1mAeuA04Db0h/nz4HJo787ssNJ3pYeT071NPr7zNcred1elf6ANaq8V7672qlmM9L3cRtwRie+v17bxGt6zl43SF3ik4H1wFER8TRAuj8yVRtrXav6M/gr4GPAcHr+auDZiHg5Pc+3c+86pNefS/Wrum5zgB3AV9Im7HWSDqNHvruI+L/AXwJPAE+TfR/30oHvr9cCquk5e1Un6RXA14FLIuIXjarWKYsG5aWR9F5ge0Tcmy+uUzWavFa5dUsmA/OAayPiZLLzQBuNf3bV+qWxs8Vkm2W/BhxGdumj0dr+/fVaQI3rnL2qkTSFLJxujIhvpOJnJM1Mr88Etqfysda1ij+DU4H3SXqc7FI5p5H1qKZJqh0snG/n3nVIrx8O7KSa6wZZu7ZFxPr0/BaywOqF7w7gPcBjEbEjInYD3wDeTge+v14LqK49Z0+SgC8BmyPiqtxLq4Ha3pxBsrGpWvkFaY/QAuC5tBmxBlgoaXr6z7cwlZUmIi6LiFkRcQzZd3JHRJwP3Amck6qNXrfaOp+T6kcqX5L2Eh0LzAXu6dBqjCkifgY8KemNqeh04GF64LtLngAWSDo0/Z7W1q/476/sAbgCBvTOItsD9hPg8rLbM452/yZZd3cTcH+6nUW27b4O2JruZ6T6IrvK6E+AB4BTcu/1QWAo3S4se91Gree72bcXb076BR0C/g44OJUfkp4Ppdfn5Ja/PK3zFuDMstcn166TgI3p+/tfZHvheua7Az4FPAI8CNxAtieu8O/Pp7qYWWX12iaemfUQB5SZVZYDyswqywFlZpXlgDKzynJAWeHSlRoekzQjPZ+enu8324ekqZLuUjZZa6vvf7GkC9vZZqsGH2ZgHSHpY8BxEbFM0heBxyPiL+rUu4jsBNS/Hsd7Hwp8P7LTTKyHuAdlnXI12dHIl5AdlPrZMeqdTzoiWdK7U29qlaQfS7pS0vmS7pH0gKTXA0TEC8DjkuZ3YkWscxxQ1hGRncP1x2RBdUlkU9iPkE5PmhMRj+eKTwQ+DLwZeD/whoiYD1wH/GGu3kbgHcW03srigLJOOpPsch3/cozXjwCeHVW2ISKejoiXyE6R+E4qfwA4JldvO9mZ9tZDHFDWEZJOIrsA3wLgI7Wz/Ed5kew8rryXco+Hc8+HGTlt2iFpeeshDigrXDoD/lqyTbsngP9GdgG0ESJiFzBJ0uiQasUbyE5ktR7igLJO+BDwRESsTc+/ALxJ0rvq1P0O2SD6eJ0KfHeC7bOK8mEGVimSTgY+GhHvL3IZ6w7uQVmlRMR9wJ3jOVCTbHD9EwU1yUrkHpSZVZZ7UGZWWQ4oM6ssB5SZVZYDyswqywFlZpX1/wGekULYKSsXuwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "animate_fig = plt.figure()\n",
     "animation_file_name = str(basin_flag) + '_' + str(storm_flag) + '_' + str(routing_method) + '.mp4'\n",
@@ -760,19 +624,18 @@
     "writer.setup(animate_fig, 'animation.mp4')\n",
     "\n",
     "while elapsed_time < model_run_time:\n",
-    "    # Setting the adaptive time step\n",
-    "    \n",
+    "    # Set the adaptive time step.\n",
     "    if routing_method == 'OverlandFlow': \n",
     "        of.dt = of.calc_time_step()\n",
     "    \n",
-    "    \n",
-    "    ## The storm starts when the model starts. While the elapsed time is less\n",
-    "    ## than the storm duration, we add water to the system as runoff.\n",
+    "    # The storm starts when the model starts. While the elapsed time is less\n",
+    "    # than the storm duration, we add water to the system as runoff.\n",
     "    if routing_method == 'OverlandFlow': \n",
     "        \n",
     "        if elapsed_time < (storm_duration):\n",
     "            of.rainfall_intensity =  runoff_ms   \n",
-    "        else: # elapsed time exceeds the storm duration, rainfall ceases.\n",
+    "        else:\n",
+    "            # elapsed time exceeds the storm duration, rainfall ceases.\n",
     "            of.rainfall_intensity = 0.0\n",
     "\n",
     "    if routing_method == 'OverlandFlow':   \n",
@@ -780,11 +643,10 @@
     "        rmg.at_node['surface_water__discharge'] = of.discharge_mapper(of.q, convert_to_volume=True)\n",
     "    else:\n",
     "        if elapsed_time < storm_duration:\n",
-    "            kw.run_one_step(dt, current_time = elapsed_time, runoff_rate = runoff_ms)\n",
+    "            kw.run_one_step(dt, current_time = elapsed_time, runoff_rate=runoff_ms)\n",
     "        else:\n",
-    "            kw.run_one_step(dt, current_time = elapsed_time, runoff_rate = 0.0)\n",
+    "            kw.run_one_step(dt, current_time = elapsed_time, runoff_rate=0.0)\n",
     "    \n",
-    "\n",
     "    if routing_method == 'OverlandFlow':\n",
     "        discharge_at_outlet.append(rmg.at_node['surface_water__discharge'][outlet_node_to_sample])\n",
     "        discharge_midstream.append(rmg.at_node['surface_water__discharge'][midstream_node_to_sample])\n",
@@ -794,54 +656,52 @@
     "        discharge_midstream.append(rmg.at_node['surface_water_inflow__discharge'][midstream_node_to_sample])\n",
     "        discharge_upstream.append(rmg.at_node['surface_water_inflow__discharge'][upstream_node_to_sample])\n",
     "    \n",
-    "    \n",
-    "    ## Append time and discharge to their lists to save data and for plotting.\n",
-    "    hydrograph_time.append(round(elapsed_time/3600,2)) #saved in hours\n",
+    "    # Append time and discharge to their lists to save data and for plotting.\n",
+    "    hydrograph_time.append(round(elapsed_time / 3600, 2)) # saved in hours\n",
     "\n",
-    "    ## output time every now and then so that you know the code is actually running\n",
-    "    ## each time loop a new image is mapped, this sequence will build the animation\n",
-    "    \n",
+    "    # Output time every now and then so that you know the code is actually running\n",
+    "    # each time loop a new image is mapped. This sequence will build the animation.\n",
     "    \n",
     "    if snap < len(ani_inc):\n",
-    "        if (elapsed_time/3600) > ani_inc[snap]:\n",
+    "        if (elapsed_time / 3600) > ani_inc[snap]:\n",
     "\n",
-    "            print('elapsed time = ' + str(round(elapsed_time/3600,2)) + ' hours')\n",
+    "            print('elapsed time = ' + str(round(elapsed_time / 3600, 2)) + ' hours')\n",
     "\n",
-    "            imshow_grid(rmg, 'surface_water__depth', colorbar_label='Depth (m)',plot_name = 'Surface Water Depth', \n",
-    "                    var_name = 'Water Depth', var_units = 'm', grid_units = ('m','m'), \n",
-    "                    cmap='Blues', limits = (0, 0.5))\n",
-    "            plt.title('{} hours'.format(str(round(elapsed_time/3600,2))),\n",
-    "                    fontsize=14) \n",
+    "            imshow_grid(rmg, 'surface_water__depth', colorbar_label='Depth (m)',\n",
+    "                        plot_name='Surface Water Depth', var_name='Water Depth',\n",
+    "                        var_units='m', grid_units=('m', 'm'), cmap='Blues',\n",
+    "                        limits=(0, 0.5))\n",
+    "            plt.title('{} hours'.format(str(round(elapsed_time / 3600, 2))),\n",
+    "                      fontsize=14) \n",
     "\n",
     "            if image_save == 1:\n",
     "                plt.savefig(str(basin_flag) + '_' + str(storm_flag) + '_' + str(routing_method) + '_' + str(ani_inc[snap]) + 'hr_map.png', format='png', dpi=2500)\n",
     "\n",
     "            writer.grab_frame()\n",
     "\n",
-    "            snap +=1\n",
+    "            snap += 1\n",
     "\n",
     "            # Remove the colorbar to reset the figure for the next animation timestep.\n",
     "            plt.gci().colorbar.remove()\n",
     "    \n",
-    "\n",
-    "    ## Updating elapsed_time\n",
+    "    # Update elapsed_time.\n",
     "    if routing_method == 'OverlandFlow': \n",
     "        elapsed_time += of.dt\n",
     "    else: \n",
     "        elapsed_time += dt\n",
     "    \n",
-    "    \n",
     "writer.finish()\n",
-    "from IPython.display import HTML\n",
+    "plt.close(animate_fig)\n",
     "\n",
-    "HTML(\"\"\"<div align=\"middle\"> <video width=\"80%\" controls loop><source src=\"animation.mp4\" type=\"video/mp4\"> </video></div>\"\"\")\n"
+    "# Display animation.\n",
+    "HTML(\"\"\"<div align=\"middle\"> <video width=\"80%\" controls loop><source src=\"animation.mp4\" type=\"video/mp4\"> </video></div>\"\"\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more on animation, see this Landlab animation tutorial see https://github.com/landlab/tutorials/blob/master/plotting/animate-landlab-output.ipynb"
+    "See [this Landlab animation tutorial](https://github.com/landlab/tutorials/blob/master/plotting/animate-landlab-output.ipynb) for more on animating model output."
    ]
   },
   {
@@ -849,7 +709,8 @@
    "metadata": {},
    "source": [
     "## 6.0 Results\n",
-    "In thise section you will start preparing your results for model simulations you ran. You will plot modeled hydrographs at each location in the same figure for the selected study domain. In this plot you will notice differences in the time to peak and peak discharge magnitudes at different locations. You may also notice differences in the results generated by the two methods.  "
+    "\n",
+    "In this section you will create figures of the model simulations you ran above. You will plot hydrographs from modeled data at each location in the same figure for the selected study domain. In this plot you will notice differences in the time to peak and peak discharge magnitudes at different locations. You may also notice differences in the results generated by the two methods."
    ]
   },
   {
@@ -861,32 +722,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJUAAAJcCAYAAABAA5WYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XecVNX9//HXoUgXQbCCAQtKKCKCgCSCGhVkJWrQxG6MJaLRFCMav181fk1BUdFfrN8oxEQ0aKIioGLDChLsfhXFgoqN3juc3x9nFoZlF5aye7e8no/HPGbm3jv3vudO2b2fOefcEGNEkiRJkiRJ2hw1sg4gSZIkSZKkyseikiRJkiRJkjabRSVJkiRJkiRtNotKkiRJkiRJ2mwWlSRJkiRJkrTZLCpJkiRJkiRps1lUkiRlLoTQKoQQQwi1SrHsmSGEl8oj1yZy/F8IoXfWObZWCKF3CGF6OWzn+yGEDypSpqyFEBaFEPbMOkehEMIeuUw1s86SpaLfMaV5nSrivtuc79UtWHepvoery2dZkqozi0qSpM0SQpgWQlgRQmhWZPqbuQOYVtkk27gQwg9zGReEEGaFEJ7ZmqwxxnYxxvHbLGCeEMKuIYS7QwhfhxAWhhCmhBB+H0JoUBbb21olHTiGEMaHEM4GiDG+GGPct/zTbd6BbVkeiBcVY2wYY/wkt93hIYRry3qbuc/vD/Lu/ySEMDeE0CvG+Hku0+qyzrG1yrNYkf86bWSZ9fZd/nu/UEh+G0KYGkJYGkL4PITw5xBCnbLMXx5yn5nFucLaohDCvKwzSZLKh0UlSdKW+BQ4qfBOCKEDUC+7OBsXQtgbuBf4DdAYaA3cBqzZgnWVabEhhNAUmEDanz1ijI2AI4AdgL3KO0+RbU2rqEXDkpTn/slKrtXI8C143BnArUC/GOPz2zyYiroFOBc4HWgE9AUOA0Zu6w1l9L7fP1dYaxhj3CGD7UuSMmBRSZK0Jf5OOjAqdAapaLNWCKFxCOHeEMLMEMJnIYT/CiHUyM2rGUIYkmsx9AnQr5jHFrbU+TKEcO1WdivpBHwaY3wmJgtjjP+KMX6e297VIYSHQgj/zLUMej2EsH9enmkhhEEhhLeBxSGEWvktPnKPH5l7vgtzXeO65D2+cwjhjdy8B3PbKalVyq+BhcCpMcZpADHGL2KMF8cY386tL4YQLgghTAWm5qbtF0J4KoQwJ4TwQQjhxLzt18nt789DCN+GEO4IIRRbBAwhXBRCeC+E0GKL93bx612vZUlp9kkI4TchhBm598FPS/N8CreTe72+AYYVk2V8COF/Qggv57Y/LqxrefdC7npersVFj9xjzgohvJ9r1fNkCOE7eeuLIYSf51qgzA0h3BpCCLl5e4cQng8hzM+93/9Z5HF7hxDOBU4BLs1t87GQWrT8q0ju/xdCGLpFL8CG++Bc4AbgqBjjK7lp67XS2th+CiH8LYTwm9zt3XOPG5j3nOeEpEkIYXRI3wNzc7db5Jb7SQhhcpFcvwohjMrd3pz37fiQvideyduHO4YQ7gupdeJ/Ql5BNJf3ohDCJ7nX5fqQ+34qZt0xpMI0IYR6IYQbQvpOmx9CeCk3be2+CyH8Afg+8Jdclr+EEPYBBgKnxBgnxBhXxRj/D/gR0CeEcFgIoXsI4ZuQ910XQjgupO8dQgg1QgiXhRA+DiHMDuk7p2mR1+5nIYTPgWeLeR4/zb2HF+ae93l58wo/NyV95nYMIYzK7ctJFFPgLo0QQtvcazUvpO/J/rnprXPTCv9G/DWEMCPvcf8IIfxyS7YpSSpbFpUkSVtiIrB97gChJvBj4B9Flvl/pFZBewK9SEWowoOUc4AC4ACgCzCgyGP/BqwC9s4tcyRwNsUIIbydOxgp7nJbbrHXgf1CCDeFEA4NITQsZlU/BB4EmgIjgEdCCLXz5p9EKn7tEGNcVczj+wMPkFoUjQL+ksu3HfAwMDy37vuB44p7Ljk/AP4dY9xUK6pjgW7Ad0PqFvdULvdOuay3hRDa5ZYdDLQhFdf2BnYHriy6whDCfwNnAr1ijGXWtaiU+2QX0vtnd+BnwK0hhCa5eZt6Prvk1vsdUsuQ4pxMej/uBGwHXJKbfkjueodci4sJIYRjgd8BxwPNgRdzmfMVAF2B/YETgaNy0/8HGAc0AVqQPhfriTHeBdwHXJfb5jGkz1OfEMIOsLblyY9JBd2tdX4u1+ExxsmbWLak/fQ80Dt3uxfwSe4a0j58McYYSf9rDiO9FnsAS8l9Nkifk31zBZf87Y3I3S7V+zbPT4DTcsvtRWrxN4z0XngfuKrI8seRvn86kz7/Z21k3YWGAAcCB+fWeylFWjzGGK8gvUcuzL2eFwKHA9NjjJOKLPsF6fv0iBjjRGAxqfVSofz9cRHpc98L2A2YS2pplq8X0JZ17798M0jv0+1Jr+lNIYTOefM39pm7FVgG7EraT6XZV+vJfZ8+Rvo87AT8ArgvhLBvjPFTYAHp+x5SUW5RCKFt7v4hpPecJKmCsagkSdpSha2VjgCmAF8WzsgrNF2eaxU0jdQq4rTcIicCQ3MtcOYAf8p77M6kbiG/jDEujjHOAG4iHTBuIMbYMca4QwmXgbllPiEdAO9O6moyK6QxbPKLS6/FGB+KMa4EbgTqAt3z5t+Sy7u0hP3xUoxxbG5Mlb+Tigvk1lEr9/iVMcZ/A5NKWAfAjsDXG5lf6E8xxjm5PAXAtBjjsFwLiNeBfwEDQgiBVMT7VW75hcAfWX9/hhDCjaQD0UNjjDNLsf2idita1AO+V8KypdknK4FrcvPHAotIBYjSPJ81wFUxxuUbeb2GxRg/zM0fSSpclOQ80v5+P1dQ/CPQKeS1VgL+HGOcl2v99lze+laSCiq7xRiXxRhLNch8jPFrUqupE3KT+gCzYoyvlebxm3AEqZDxTimWLWk/PQ98P9ey5BDgOqBnbl6v3HxijLNzrQKX5F6rP+TmE2NcAjxKrittrri0HzCqlK9zcVk/jjHOBx4HPo4xPp17zR5kXcGi0ODcuj8HhpLXpbc4ued6FnBxjPHLGOPqGOMrMcblG3tcTjNK/lx/nZsPqVhZuD8aAUezroB5HnBFjHF6bptXkz7j+V3drs59b27wvo8xjsntn5jr7jiOVLwpVNJnriapRdWVuXW/Syr8F/V63uf/lmLmdwcakj4rK2KMzwKjWbffnwd6hRB2yd1/KHe/NakQ9lYx65QkZcyikiRpS/2d9Cv6mRTp+kY6QNoO+Cxv2mekog6kX9m/KDKv0HeA2sDXecWJO0m/bG+xGOPEGOOJMcbmpAOpQ4Ar8hb5Im/ZNcD0XM4N5pfgm7zbS4C6uYO93YAvc602SrOu2aTWAJuSv47vAN2KFHROIbU8aA7UB17Lm/dEbnqhHUgtev6UOyAH1p7RKn+dewD5LcNOzlvHV0WLekBJBZTS7JPZRVqELSEdkJbm+cyMMS4rYduFir5exbVeK/Qd4Oa87c0BAuvezxtb36W5ZSfluvtsTguPvwGn5m6fSl4rpRDCbXl5bgNOzntd3t7Een9OagH011zxZmOKfV4xxo9JRYdOpM/TaOCrEMK+5BWVQgj1Qwh3htRdbAGpULZDWNfFawTrigonA4/kik2leZ2L+jbv9tJi7hd9jYt+B+3GxjUjFZs/3sRyxZlFyZ/rXXPzIe2P40MavPt44PUYY+H343eAh/P2x/vAamDnvHWV+N0SQugbQpgYUtfEeaSCVf4JFzb2matFyd/ZhTrnff4vKmb+bsAXcf1WmPl/Fwpbvx1Cep+MJ72XepFavm32GHiSpLJnUUmStEVyBzqfkg5M/l1k9izWtdAotAfrWjN9DbQsMq/QF8ByoFneAcr2McZ2FCN3oL6ohMsdJWT/Ty5z+7zJa/PkWiS0AL7Kf1hx6yqFr4Hdixy8tyxpYeBp4LhQwvguJeT5Ani+SFGnYYzxfNJrsRRolzevcYwx/wB7Lqm107AQQs+1G0hntMovEn0O5LcMG8GW2dx9kq80z2dLX6uSHvsFcF6R/Vsv5sYi2ujKYvwmxnhOjHE3UkuT20JufJ5SbPcRoGMIoT3p9bkvb70D816XgcCIvGwdNxFrBqk71vdJBakt9Typ6+p2McYvc/dPJ3X1ezO3zG+AfYFuMcbtWde9sPC1Hwc0CyF0IhWXCt9TpXmdt1bR76CvSlowL9MySjeeUNHX81mgZQjhoPyJIYSWpBY8zwDEGN8jFVr6sn7XN0jvw75F3od1c/u+pO0WbqcOqfXiEGDn3PtmLOteh42ZSeqOXNJ3dml9RdoH+d9t+X8Xnie9J3vnbr9Eav22tkgpSap4LCpJkrbGz4DDYoyL8yfG1AVsJPCHEEKjXDehX7Nu3KWRwEUhhBa5MTsuy3vs16QDzRtCCNuHNDjtXiGEXhQjxtgurjvjUNHLzwFCCN8LIZwTQtgpd38/0hhIE/NWdWAI4fhc66JfkgpbE4tubwtMILUmuDCkQXx/CBy0keVvJHX1+Fth96qQBkK+MYRQUrFgNNAmhHBaCKF27tI1hNA29+v+/5LGT9kpb33rjbkSYxxPat30cAih21Y839LY3H2yVmmfz1aYSeo+t2fetDuAy0NujKqQBpI/obgHFxVCOCGsG/R8Lumgf3Uxi35bZJvkWls9RCosTMp109omYoxfkcbu6RNCuGkLV/M8cCHrBjcfTxon56XcdwCks5wtJQ183pQi4xrlWsY8BFxPGqPoqdz0sn6dAX4b0kDiLYGLgX9ubOFcpnuAG0MIu4V0woEeuYJNUeu9njHGD0nvo/tCGpC7Zu799C/g6Rjj03mPHUEaP+kQUre9QneQvlMLvxea5z47pbEdUIdcgSiE0Jc0Vt0m5V7LfwNX51qefZd0cobN9SppzKhLc99RvYFjSGPREWOcSnqvnAq8EGNcQNqPP8KikiRVWBaVJElbLDc+R0kD/f6CdADxCekX5xGkAzJIB4tPksbIeJ0NWzqdTjoIeo90IP4QpesSVpJ5pCLSOyGERaRuNA+TxoEp9ChpHKi5pLGfjo9pfKWtEmNcQerG8rNcjlNJRaBix2GJaYypg0ktvV4NISwktWKYD3xUwmMWkg4Qf0JqDfANaZDjwoPdQbnHTsx1QXqa1Hqk6HqeIg3gOyqEcOAWPN1S2dx9UoxSPZ8tzLaENO7Py7luRt1jjA+T9ucDue29S2pJUhpdSa/jItLA1BfHNChxUXeTBl2fF0J4JG/634AObJsButcT0yDRh5HG5fnTppYvxvOkolFhUeklUpe1F/KWGQrUI7XymUj67BU1gjRA/YNFul+V2euc8yjwGqlV1RjSa7Apl5DGovoPqRvkYIr/f/pm0n6dG9aNL3Qh8FdScb3we2g8qWiS735Sa51nY4yz8qbfTHoPjct9L0wkDda/SbnviItIBf25pFZQo0rz2LzsDUnfLcMp5qyKpciwgvQ93Jf0frgNOD3GOCVvsedJ3fA+z7sfgDc2d3uSpPIR1h/OQJKk6ieEcDWwd4zx1E0tu4229ypwR4xxsw/Mqir3SfFCCHuQBsLfJddyQ9tACCEC+8QYiy3USpKk0rGlkiRJZSyE0CuEsEuuq9cZQEeKb7FRbbhPNi039syvgQcsKEmSpIqo1qYXkSRJW2lfUreThqQzRw3IjR1VnblPNiKE0IA0nsxnQJ+M40iSJBXL7m+SJEmSJEnabHZ/kyRJkiRJ0mar1N3fmjVrFlu1apV1DEmSJEmSpCrjtddemxVjbL6p5Sp1UalVq1ZMnlzSmawlSZIkSZK0uUIIn5VmObu/SZIkSZIkabNZVJIkSZIkSdJms6gkSZIkSZKkzVapx1QqzsqVK5k+fTrLli3LOkqVVbduXVq0aEHt2rWzjiJJkiRJkjJS5YpK06dPp1GjRrRq1YoQQtZxqpwYI7Nnz2b69Om0bt066ziSJEmSJCkjVa7727Jly9hxxx0tKJWREAI77rijLcEkSZIkSarmqlxRCbCgVMbcv5IkSZIkqUoWlSRJkiRJklS2LCpVAMOHD+err75ae793795Mnjx5o48ZOnQoS5YsKetokiRJkiRJxbKoVAEULSqVhkUlSZIkSZKUJYtKZeTGG2+kffv2tG/fnqFDhzJt2jTat2+/dv6QIUO4+uqreeihh5g8eTKnnHIKnTp1YunSpeutZ9y4cfTo0YPOnTtzwgknsGjRIm655Ra++uorDj30UA499NDyfmqSJEmSJEnUyjpAmfrlL+HNN7ftOjt1gqFDN7rIa6+9xrBhw3j11VeJMdKtWzd69epV7LIDBgzgL3/5C0OGDKFLly7rzZs1axbXXnstTz/9NA0aNGDw4MHceOONXHnlldx4440899xzNGvWbJs9NUmSJEmSpNKq2kWljLz00kscd9xxNGjQAIDjjz+eF198cbPXM3HiRN577z169uwJwIoVK+jRo8c2zSpJkiRJkrQlqnZRaRMtispKjHGDafPmzWPNmjVr7y9btqxU6zniiCO4//77t2k+SZIkSZKkreWYSmXgkEMO4ZFHHmHJkiUsXryYhx9+mL59+zJjxgxmz57N8uXLGT169NrlGzVqxMKFCzdYT/fu3Xn55Zf56KOPAFiyZAkffvjhRh8jSZIkSZJUHqp2S6WMdO7cmTPPPJODDjoIgLPPPpuuXbty5ZVX0q1bN1q3bs1+++23dvkzzzyTn//859SrV48JEyasnd68eXOGDx/OSSedxPLlywG49tpradOmDeeeey59+/Zl11135bnnnivfJyhJkiRJkqq9UFxXrcqiS5cucfLkyetNe//992nbtm1GiaoP97MkSZIkSVVTCOG1GGOXTS1n9zdJkiRJkiRtNotKkiRJkiRJ2mwWlSRJkiRJkrTZLCpJkiRJkiRps1lUkiRJkiRJ0marlXUASdI2snIlLF2aLkuWrLu9dCksX57mr1q17nprb69eDTHCmjXrLvn3t/R2jOsusOW3i5uXr+i0rb2/MWW1rKTs1awJV18NAwZknUSSpHJnUSkjo0aN4r333uOyyy7bYF7Dhg1ZtGhRiY/94x//yO9+97uyjCeprK1YAbNnw6xZ6TJzZrqeP3/DglD+/ZJuL12aCj1loWZNqF0batVKl9q107SaNaFGjXQJYd3tovc353bhNaTbIWzd7eLm5Ss6bWvvb0xZLSspW++8A2eeCQccAHvtlXUaSZLKVYiV+BfRLl26xMmTJ6837f3336dt27YZJdo2NlVUKml+jJEYIzVqlH2vxqqwn6VtZs2aVAwqLAwVLRQVd3/+/I2vs149qF8/XW/J7aL369RJxaCixaFN3a5VywKHJG3M559Dx47Qrh288EIquEuSVMmFEF6LMXbZ1HK2VCoD06ZNo0+fPnzve99j4sSJ7L///vz0pz/lqquuYsaMGdx333289957TJ48mb/85S98+umnnHzyyaxatYo+ffqsXc/XX3/Nj3/8YxYsWMCqVau4/fbbGTNmDEuXLqVTp060a9eOP/zhD/Tt25dDDz2UCRMm8Mgjj/DBBx9w1VVXsXz5cvbaay+GDRtGw4YNueaaa3jsscdYunQpBx98MHfeeSchBHr37s0BBxzAa6+9xsyZM7n33nv505/+xDvvvMOPf/xjrr322gz3plQBxAjTp8O77667fPbZukLR7NmpK1hx6tSB5s3TpVkz2HPPdF14v/BSeL9xY6hb10KOJFUWe+wBt94Kp54K110Hl1+edSJJkspNlW6p9Msnfsmb37y5TbfZaZdODO0zdKPLTJs2jb333ps33niDdu3a0bVrV/bff3/uvvtuRo0axbBhwzj22GPXFpX69+/PgAEDOP3007n11lsZNGgQixYt4oYbbmDZsmVcccUVrF69miVLltCoUaP1WipNmzaNPffck1deeYXu3bsza9Ysjj/+eB5//HEaNGjA4MGDWb58OVdeeSVz5syhadOmAJx22mmceOKJHHPMMfTu3Ztu3boxePBgbr75ZgYPHsxrr71G06ZN2WuvvXjrrbfYcccdS9zPUpUya9a6wtE776y7vWDBumV22y11ccgvDJVUJKpf3wKRJFV1McJPfgL//jdMmpS6wkmSVInZUiljrVu3pkOHDgC0a9eOww8/nBACHTp0YNq0aest+/LLL/Ovf/0LSMWeQYMGAdC1a1fOOussVq5cybHHHkunTp2K3dZ3vvMdunfvDsDEiRN577336NmzJwArVqygR48eADz33HNcd911LFmyhDlz5tCuXTuOOeYYAPr37w9Ahw4daNeuHbvuuisAe+65J1988cUGRSWp0lu4EN57b/3C0bvvwrffrlumSRPo0CH9+ty+fbq0awe54qwkSUD68eD22+HFF9PfjMmTU9djSZKquCpdVNpUi6KyVKdOnbW3a9SosfZ+jRo1WFXMYLqhmJYMhxxyCC+88AJjxozhtNNO47e//S2nn376Bss1aNBg7e0YI0cccQT333//esssW7aMgQMHMnnyZFq2bMnVV1/NsmXLNsibn3VjeaVKY/Xq9YtGhZf84m79+qlYdPTR64pH7dvDrrvaykiSVDpNm8KwYdCnD/zud3DTTVknkiSpzFXpolJl0bNnTx544AFOPfVU7rvvvrXTP/vsM3bffXfOOeccFi9ezOuvv87pp59O7dq1WblyJbVr195gXd27d+eCCy7go48+Yu+992bJkiVMnz6dnXbaCYBmzZqxaNEiHnroIQZ46ltVVcuWwTPPwCOPwKhRMGNGml6rFuy3H3TvDmefva541Lr1ujOOSZK0pY46Ci68EIYOhYICOPzwrBNJklSmLCpVADfffDMnn3wyN998Mz/60Y/WTh8/fjzXX389tWvXpmHDhtx7770AnHvuuXTs2JHOnTvzhz/8Yb11NW/enOHDh3PSSSexfPlyAK699lratGnDOeecQ4cOHWjVqhVdu3YtvycolYd582Ds2FRIevxxWLQIGjVKrY/69UvjW7RpA9ttl3VSSVJVNngwPPUUnHkmvP126kotSVIVVaUH6lbZcT+rQvjyy9QS6ZFH4NlnYdUq2Hln+OEP4bjj4NBD09nXJEkqT5MnQ48ecOKJkNcKXZKkysKBuiVVTVOmpCLSww+nM+wA7LMP/PrXcOyx0K2bXdkkSdnq0gWuvDJdjjkmnRlOkqQqyKKSpIptzRr4z39SEemRR+CDD9L0rl3hD39IhaS2bR1QW5JUsVx+OYwZA+efD9//Puy+e9aJJEna5iwqSap4VqyA8eNTIenRR+Hrr9Mg2717wy9+Af37Q8uWWaeUJKlktWrB3/8OnTrBT38KTzxhS1pJUpVjUUlSxbBsGTz2WCokjRkDCxZA/frQt29qjdSvn4OdSpIql332gRtvhJ//HG69Nf0wIklSFWJRSVK2YoSHHoJLL4Vp06BZMxgwIBWSfvADqFcv64SSJG25c89NJ5W49NL0d80TnUiSqhDb4ErKzuTJcMgh6ew4jRrB2LHwzTdw991pYFMLSpKkyi6E9HetQQM49dTUxVuSpCrColIFNW3aNEaMGJF1DKlsfPklnHFGGmz7gw/gzjvhjTdSV7eaNbNOJ0nStrXLLnDXXfD66/A//5N1GkmSthmLShXUxopKq1atKuc00jayZAlccw20aQMPPJC6AkydmroGWEySJFVlxx8PZ54Jf/wjTJiQdRpJkrYJi0plYNq0abRv337t/SFDhnD11VfTu3dvfvnLX3LwwQfTvn17Jk2aBMDzzz9Pp06d6NSpEwcccAALFy7ksssu48UXX6RTp07cdNNNDB8+nBNOOIFjjjmGI488EoDrr7+erl270rFjR6666qq12zv22GM58MADadeuHXfdddfa6Q0bNmTQoEEceOCB/OAHP2DSpEn07t2bPffck1GjRpXT3lG1tGYN/OMfsO++cNVVcPTR8P77MHgwNG6cdTpJksrHzTens5eedhosWpR1GkmStlqVHqj7l7+EN9/ctuvs1AmGDt3yxy9evJhXXnmFF154gbPOOot3332XIUOGcOutt9KzZ08WLVpE3bp1+fOf/8yQIUMYPXo0AMOHD2fChAm8/fbbNG3alHHjxjF16lQmTZpEjJH+/fvzwgsvcMghh3DPPffQtGlTli5dSteuXfnRj37EjjvuyOLFi+nduzeDBw/muOOO47/+67946qmneO+99zjjjDPo37//NtpLUp5XXoFf/QomTYLOneG++9I4SpIkVTfbbw/33gu9e8NvfpO6f0uSVInZUqmcnXTSSQAccsghLFiwgHnz5tGzZ09+/etfc8sttzBv3jxq1Sq+1nfEEUfQtGlTAMaNG8e4ceM44IAD6Ny5M1OmTGHq1KkA3HLLLey///50796dL774Yu307bbbjj59+gDQoUMHevXqRe3atenQoQPTpk0r42euauezz+Ckk6BnT/jiCxg+HP7zHwtKkqTq7ZBD4Le/TWMs5X48lCSpsqrSLZW2pkXR1qhVqxZr1qxZe3/ZsmVrb4cQ1ls2hMBll11Gv379GDt2LN27d+fpp58udr0NGjRYezvGyOWXX85555233jLjx4/n6aefZsKECdSvX5/evXuv3X7t2rXXbr9GjRrUqVNn7W3HadI2s3Ah/PnPcOON6f5//3caO6lhw2xzSZJUUVxzDTzxBPzsZ/Duu9C8edaJJEnaIrZUKgM777wzM2bMYPbs2SxfvnxtFzaAf/7znwC89NJLNG7cmMaNG/Pxxx/ToUMHBg0aRJcuXZgyZQqNGjVi4cKFJW7jqKOO4p577mFRrj/+l19+yYwZM5g/fz5NmjShfv36TJkyhYkTJ5btk5UKrV4N99yTBuH+4x/hRz+CDz9M/zhbUJIkaZ06ddJYg/PmpZNVxJh1IkmStkiVbqmUldq1a3PllVfSrVs3WrduzX777bd2XpMmTTj44INZsGAB99xzDwBDhw7lueeeo2bNmnz3u9+lb9++1KhRg1q1arH//vtz5pln0qRJk/W2ceSRR/L+++/To0cPIA3C/Y9//IM+ffpwxx130LFjR/bdd1+6d+9efk9c1df48WncpDffhO7d4ZFHoFu3rFNJklRxdeiQfoS55JLURfynP806kSRJmy3ESvzLSJcuXeLkyZPXm/ZZRCJiAAAgAElEQVT+++/Ttm3bjBJtXO/evRkyZAhdunTJOspWq8j7WeXo44/TuBAPP5zOZnPddfDjH0ORbp6SJKkYa9bA4YfD5Mnw9tvQunXWiSRJAiCE8FqMcZPFC7u/Sdp88+enYlLbtjBuHFx7LXzwAfzkJxaUJEkqrRo1UiulGjXg9NNTV3JJkiqRMisqhRDuCSHMCCG8W8y8S0IIMYTQLHc/hBBuCSF8FEJ4O4TQuaxyZWn8+PFVopWSqrkxY2DvveGGG+DUU2HqVLjiCqhXL+tkkiRVPt/5DvzlL/DSSzBkSNZpJEnaLGXZUmk40KfoxBBCS+AI4PO8yX2BfXKXc4Hbt2bDlblLX2Xg/q3GxoyB446DFi1SU/177oFdd806lSRJldupp8KAAemMqW++mXUaSZJKrcyKSjHGF4A5xcy6CbgUyK9M/BC4NyYTgR1CCFt0pFq3bl1mz55t4aOMxBiZPXs2devWzTqKytuTT8Lxx6eBRZ97DjpXyQaFkiSVvxDgjjugWbNUYFq2LOtEkiSVSrme/S2E0B/4Msb4Vlh/3JXdgS/y7k/PTfu6mHWcS2rNxB577LHBNlq0aMH06dOZOXPmNkyufHXr1qVFixZZx1B5evppOPZY+O534amnYIcdsk4kSVLVsuOOqQVw376pW/kNN2SdSJKkTSq3olIIoT5wBXBkcbOLmVZsU6MY413AXZDO/lZ0fu3atWntmTOkbWf8eOjfH/bZJxWUmjbNOpEkSVVTnz4wcCDceCP06weHHZZ1IkmSNqo8z/62F9AaeCuEMA1oAbweQtiF1DKpZd6yLYCvyjGbpOK8+GL6p7Z169RaqVmzrBNJklS1XX89tGkDZ54J8+ZlnUaSpI0qt6JSjPGdGONOMcZWMcZWpEJS5xjjN8Ao4PTcWeC6A/NjjBt0fZNUjl5+OTXB32MPePZZ2GmnrBNJklT11a8P//gHfPUVXHNN1mkkSdqoMisqhRDuByYA+4YQpocQfraRxccCnwAfAf8LDCyrXJJKYeLEVFDaffdUUNp556wTSZJUfXTtCieemMZYWrw46zSSJJWoLM/+dlKMcdcYY+0YY4sY491F5reKMc7K3Y4xxgtijHvFGDvEGCeXVS5Jm/Cf/8BRR6WWSc8+C7tu0YkYJUnS1hg4EObPhwceyDqJJEklKs8xlSRVdK+/Dkcemc5A89xzqaWSJEkqfz17QocOcOutEIs9f40kSZmzqCQpeestOOII2H771EKpZctNP0aSJJWNEFJrpTfegEmTsk4jSVKxLCpJgnffhR/8IA0O+txz0KpV1okkSdIpp0CjRnDbbVknkSSpWBaVpOruvffgsMNgu+1SQWnPPbNOJEmSIBWUTj8d/vlPmDUr6zSSJG3AopJUnX3wQSoo1ayZCkp77511IkmSlO/882H5chg2LOskkiRtwKKSVF1NnQqHHpoG/3z2WWjTJutEkiSpqHbtoFcvuP12WLMm6zSSJK3HopJUHX3ySWqhtHJlKii1bZt1IkmSVJKBA+HTT+HJJ7NOIknSeiwqSdXNtGmphdKSJfDMM+kXUEmSVHEdeyzssosDdkuSKhyLSlJ18vnnqaC0cCE8/TR07Jh1IkmStCnbbQfnnANjxqQfhyRJqiAsKknVxfTpqaA0dy489RQccEDWiSRJUmmdey7UqAF33pl1EkmS1rKoJFUHX32VxlCaNQvGjYMDD8w6kSRJ2hwtWkD//vDXv6azwUmSVAFYVJKqum++SQWlr7+GJ56Agw7KOpEkSdoSAwemH4geeijrJJIkARaVpKpt7lw4/PDU9e3xx6FHj6wTSZKkLXXYYdCmjQN2S5IqDItKUlV28cXwwQcwejR873tZp5EkSVujRg04/3x45RV4882s00iSZFFJqrIeewz+/nf43e+gd++s00iSpG3hjDOgXj24/fask0iSZFFJqpLmzElnienYEf7rv7JOI0mStpUmTeDkk+Ef/4D587NOI0mq5iwqSVXRxRengTyHD4fttss6jSRJ2pYGDoQlS+Dee7NOIkmq5iwqSVXNqFHp18vf/Q4OOCDrNJIkaVvr3Bm6dUsDdseYdRpJUjVmUUmqSubMgfPOg/33hyuuyDqNJEkqKwMHwpQpMH581kkkSdWYRSWpKrnoIru9SZJUHZx4IjRtmlorSZKUEYtKUlXx6KNw331pYO5OnbJOI0mSylLduvCzn8HDD8NXX2WdRpJUTVlUkqqC2bNTt7dOndJYSpIkqeo77zxYswb+93+zTiJJqqYsKklVwUUXpcLS8OFQu3bWaSRJUnnYay/o0wfuugtWrsw6jSSpGrKoJFV2jzwCI0bAf/93GqBbkiRVHwMHpu5vo0ZlnUSSVA2FWIlPQ9qlS5c4efLkrGNI2Zk9G9q1g912g1dftZWSJEnVzerVqcXSXnvBM89knUaSVEWEEF6LMXbZ1HK2VJIqs1/8AubMsdubJEnVVc2a8POfw7PPwvvvZ51GklTNWFSSKquHH4b770/d3jp2zDqNJEnKyllnwXbbwR13ZJ1EklTNWFSSKqNZs9Kvkp07w2WXZZ1GkiRlaaed4IQTUsvlxYuzTiNJqkYsKkmV0YUXwty5dnuTJEnJwIGwYEE6eYckSeXEopJU2fzrX/DPf8KVV0KHDlmnkSRJFUGPHukssLfdBpX4RDySpMrFopJUmcycCeefn7q9DRqUdRpJklRRhJBaK735JkycmHUaSVI1YVFJqkwuvBDmzbPbmyRJ2tDJJ8P226fWSpIklQOLSlJl8dBDMHIkXHWV3d4kSdKGGjaEM85I/y/MnJl1GklSNWBRSaoMZs5MTdoPPNBub5IkqWTnnw8rVsA992SdRJJUDVhUkiqDCy6A+fNTt7datbJOI0mSKqq2beHQQ+GOO2D16qzTSJKqOItKUkX34IPpctVV0L591mkkSVJFN3AgTJsGTzyRdRJJUhVnUUmqyGbMSP8YdukCl16adRpJklQZ/PCHsOuuDtgtSSpzFpWkiuyCC2DBAru9SZKk0qtdG849Fx5/HD75JOs0kqQqzKKSVFGNHJnO+Hb11dCuXdZpJElSZXLOOVCjBtx5Z9ZJJElVmEUlqSKaMSO1UuraFX7726zTSJKkymb33eHYY+Huu2HZsqzTSJKqKItKUkUTYxpHyW5vkiRpawwcCLNnpxN+SJJUBiwqSRXNyJHwr3/B738P3/1u1mkkSVJldeihsO++DtgtSSozFpWkiuTbb1O3t4MOgksuyTqNJEmqzEJIrZUmToTXX886jSSpCrKoJFUUMcL558PChTBsmN3eJEnS1jv9dKhfH26/PeskkqQqyKKSVFE88AA8/DBcc43d3iRJ0raxww5wyilw330wb17WaSRJVYxFJakimDkTLrwwdXv7zW+yTiNJkqqSgQNh6VL429+yTiJJqmIsKkkVwdChMHcu3HOP3d4kSdK21akT9OiRBuyOMes0kqQqxKKSlLUFC+DWW+H446Fdu6zTSJKkqmjgQPjwQ3j22ayTSJKqEItKUtbuugvmz4dBg7JOIkmSqqoBA6BZs9RaSZKkbcSikpSl5cvhppvg0EOha9es00iSpKqqbl342c/g0Udh+vSs00iSqgiLSlKW7rsPvvrKVkqSJKnsnXcerFkDd9+ddRJJUhVhUUnKypo1cN11afDMI4/MOo0kSarqWreG730PHnkk6ySSpCrCopKUlVGj4IMPUiulELJOI0mSqoOCAnjzTbvASZK2CYtKUhZihMGD0y+GAwZknUaSJFUXBQXpesyYbHNIkqoEi0pSFl58ESZOhEsugVq1sk4jSZKqi7Zt049ao0dnnUSSVAVYVJKyMHgwNG8OP/1p1kkkSVJ1EkJqrfT007BkSdZpJEmVnEUlqby98w6MHQsXXQT16mWdRpIkVTfHHAPLlsFzz2WdRJJUyVlUksrbdddBgwYwcGDWSSRJUnV0yCHQsKFd4CRJW63MikohhHtCCDNCCO/mTbs+hDAlhPB2COHhEMIOefMuDyF8FEL4IIRwVFnlkjL12Wdw//1w7rnQtGnWaSRJUnVUpw4ceWQqKsWYdRpJUiVWli2VhgN9ikx7CmgfY+wIfAhcDhBC+C7wE6Bd7jG3hRBqlmE2KRs33pjGMvjVr7JOIkmSqrOCApg+Hd5+O+skkqRKrMyKSjHGF4A5RaaNizGuyt2dCLTI3f4h8ECMcXmM8VPgI+CgssomZWL2bPjrX+GUU6Bly6zTSJKk6uzoo9P1Y49lm0OSVKllOabSWcDjudu7A1/kzZuem7aBEMK5IYTJIYTJM2fOLOOI0jb0l7+ks6xcemnWSSRJUnW3885w0EGOqyRJ2iqZFJVCCFcAq4D7CicVs1ixHbxjjHfFGLvEGLs0b968rCJK29bixfD//l8628p3v5t1GkmSpNQFbtIk+PbbrJNIkiqpci8qhRDOAAqAU2JcOzLgdCC/P1AL4KvyziaVmXvuSd3fBg3KOokkSVJSUJAG6n788U0vK0lSMcq1qBRC6AMMAvrHGJfkzRoF/CSEUCeE0BrYB5hUntmkMrNyJdxwA/TsmS6SJEkVQadOsNtudoGTJG2xWmW14hDC/UBvoFkIYTpwFelsb3WAp0IIABNjjD+PMf5fCGEk8B6pW9wFMcbVZZVNKlcjR8Jnn6Xub5IkSRVFCKm10ogRsGIFbLdd1okkSZVMWNcDrfLp0qVLnDx5ctYxpJLFmH4FXLUK3nkHamQ5Nr4kSVIRo0enMR+fegp+8IOs00iSKogQwmsxxi6bWs4jXKksPfEEvP12OuObBSVJklTRHHYY1K1rFzhJ0hbxKFcqS3/+M7RsCSedlHUSSZKkDdWvD4cfDo89llpYS5K0GSwqSWVl4kR44QX49a8do0CSJFVcBQXwySfwwQdZJ5EkVTIWlaSyMngwNGkCZ5+ddRJJkqSS9euXrh97LNsckqRKx6KSVBamTIFHH4ULL4SGDbNOI0mSVLKWLWH//R1XSZK02SwqSWXh+uvToJe/+EXWSSRJkjatoABefhnmzMk6iSSpErGoJG1rX34Jf/87nHUWNG+edRpJkqRNKyiA1avhySezTiJJqkQsKknb2tChsGYN/OY3WSeRJEkqna5d049hdoGTJG0Gi0rStjRvHtx5J5x4IrRunXUaSZKk0qlZE44+Gh5/HFatyjqNJKmSsKgkbUu33w4LF8Kll2adRJIkafMUFMDcuTBhQtZJJEmVhEUlaVtZtgxuvhmOOgo6dco6jSRJ0uY58kioXdsucJKkUrOoJG0rf/sbfPstDBqUdRJJkqTNt/320KuXRSVJUqlZVJK2hdWrYciQNMhl795Zp5EkSdoyBQXw3nvwySdZJ5EkVQIWlaRt4d//ho8+Sq2UQsg6jSRJ0pYpKEjXtlaSJJWCRSVpa8UIgwfDPvvAscdmnUaSJGnL7bUX7LefRSVJUqlYVJK21rPPwmuvwW9/m07HK0mSVJkVFMD48emMtpIkbYRFJWlrDR4Mu+wCp52WdRJJkqStV1AAK1fCU09lnUSSVMFZVJK2xuuvp3+4fvUrqFs36zSSJElb7+CDYYcd7AInSdoki0rS1rjuunT63fPOyzqJJEnStlG7NvTpA2PGwJo1WaeRJFVgFpWkLfXxx/Dgg3D++dC4cdZpJEmStp2CApgxAyZPzjqJJKkCs6gkbakbboBateDii7NOIkmStG317Qs1atgFTpK0URaVpC3x7bdwzz1wxhmw665Zp5EkSdq2mjaFnj0tKkmSNsqikrQlbrkFVqyASy7JOokkSVLZKCiAN96A6dOzTiJJqqAsKkmba+FCuO02OP54aNMm6zSSJEllo6AgXY8Zk20OSVKFZVFJ2lx33QXz5sGgQVknkSRJKjtt20Lr1naBkySVyKKStDlWrICbboJDD4WuXbNOI0mSVHZCSK2Vnn4alizJOo0kqQKyqCRtjkcfhS+/hEsvzTqJJElS2SsogGXL4Lnnsk4iSaqALCpJm2PkSNhlFzjiiKyTSJIklb1evaBBA7vASZKKZVFJKq3Fi9NAlT/6EdSsmXUaSZKkslenDhx5ZCoqxZh1GklSBWNRSSqtMWNg6VI48cSsk0iSJJWfggKYPh3efjvrJJKkCsaiklRahV3fevbMOokkSVL5OfrodG0XOElSERaVpNJYtCi1VBowwK5vkiSpetllFzjoIHjssayTSJIqGItKUmmMGZPOfHLCCVknkSRJKn8FBTBpEnz7bdZJJEkViEUlqTRGjoRdd7XrmyRJqp4KCtJA3Y8/nnUSSVIFYlFJ2pRFi2DsWM/6JkmSqq9OnWC33RxXSZK0HotK0qaMHp26vnnWN0mSVF2FkForPfkkrFiRdRpJUgVhUUnalAcftOubJElSQUFqwf3CC1knkSRVEBaVpI0p7Po2YADU8OMiSZKqscMPh7p17QInSVrLo2RpY+z6JkmSlNSvD4cdBo89lgbtliRVexaVpI0ZOTINSnnwwVknkSRJyl5BAXzyCXzwQdZJJEkVgEUlqSQLF9r1TZIkKV+/funaLnCSJCwqSSUbPRqWL4cTTsg6iSRJUsWwxx7QsWPqAidJqvYsKkklseubJEnSho45Bl5+GebMyTqJJCljFpWk4ixcCI8/btc3SZKkogoKYPVqePLJrJNIkjLm0bJUnMceS13fPOubJEnS+rp2hebNHVdJkmRRSSrWgw/C7rtDjx5ZJ5EkSapYataEo49OrbpXrco6jSQpQ7WyDiBVOAsWpH+Sfv5zu74VEWNk4YqFLFi+gOWrlrNi9QpWrF7B8tV5t/Omb2xe/vTC+ytXr2RNXMPquJo1cc16l9Vr1p+2ucvEGInEtc8jEokxdz93u6RpJT2m6L5Z736R+Vu6zEZfj2IeL0kqXzVCDW7uczMndzg56yjlq6AA/vY3mDABvv/9rNNIkjJiUUkqqrDrWxU+69vyVcuZu2wuc5bOYe7S3HXu/tppyzacN3fpXFbH1dskw3Y1t2O7mttRp2adtbdr16xNzVCTGqEGNWuk6/xL4by192vUpFaNWptcJhAIIay9BtabBqw3f4NpxSxTuI58hdPX3i8yf0uX2ZjiHi9JKj8PT3mYu9+4u/oVlY48EmrVSl3gLCpJUrVlUUkqqpJ3fZu3bB4fzPqA92e9z5RZU5g6Zyqzl8xerzi0ZOWSEh8fCOxQdwea1GtC03pNaVK3Ca12aEWTurn79ZrQuE5j6tSqs0FRqHBa0elF59WuUXuzCieSJFVU9WvX58aJN7Jg+QK2r7N91nHKz/bbQ69eqag0eHDWaSRJGbGoJOVbsACeeKLCd31bE9cwfcF0psyawpRZU3h/5vtMmZ1uf7Pom7XL1a5Rm72a7sVODXZizyZ70rRe07WFosICUdH7jes0pmaNmhk+O0mSKo+CNgVc98p1jPt4HAO+OyDrOOWroAB+9Sv45BPYc8+s00iSMmBRScpXwc76tmzVMqbOnrq2eDRldiogfTD7g/VaG+1QdwfaNmtL3737sl+z/WjbrC37NduP1k1aU6uGH3NJkspKj5Y9aFK3CWOmjqm+RaXRo+Gii7JOI0nKgEebUr6RI6FFC+jevVw3u2rNKv7z5X/4v5n/t66ANGsKn877lDVxzdrlWu3Qiv2a7Uev7/Riv2b7pQJS87Y0r9/c7mSSJGWgVo1a9Nm7D2OnjmVNXEONUHFbOm9ze+8N++5rUUmSqjGLSlKhwq5vAweWS9e3GCOTvpzEiHdG8M//+yffLv4WgLq16rLvjvvSZbcunNrx1LXFozY7tqF+7fplnkuSJG2efvv04/5372fyV5M5aPeDso5Tvo45Bm6+GRYuhEaNsk4jSSpnFpWkQqNGwYoVZd717f2Z7zPinRGMeHcEn8z9hDo161DQpoAft/sxXXbrwh6N93BMI0mSKpE+e/ehRqjB6A9HV7+iUr9+MGQIPPUUHH981mkkSeXMopJU6MEHU9e3bt22+aqnL5jOA+8+wH3v3Meb37xJjVCDw1ofxn8f8t8ct99xNK7beJtvU5IklY8d6+9IjxY9GDN1DNccek3WccpXz57pTHCPP25RSZKqIYtKEsD8+anr2wUXbLOub3OWzuGh9x5ixDsjeOGzF4hEDtr9IIYeNZQT253Iro123SbbkSRJ2StoU8Dlz1zOVwu/YrdGu2Udp/zUrg1HHJGKSjGCYzxKUrVSjUYSlDaisOvbCSds1WqWrFzCA+8+QP/7+7PLkF04b/R5fLPoG37f+/dM/cVUXj37VS7ufrEFJUmSqph++/QDYOzUsRknyUDfvvDll/DOO1knkSSVM1sqSZC6vrVsuUVd31auXsnTnzzNiHdH8PD7D7N45WJ2b7Q7F3e7mJM7nEynXTp5ZjZJkqq49ju1Z4/GezD6w9Gc3fnsrOOUr7590/Xjj0PHjtlmkSSVqzIrKoUQ7gEKgBkxxva5aU2BfwKtgGnAiTHGuSEdcd8MHA0sAc6MMb5eVtmk9cyfD08+uVld39bENUz4YgIj3hnByPdGMmvJLHaouwMndziZkzuczPf3+L6DbUuSVI2EEOi3Tz/ufetelq1aRt1adbOOVH522w323x/GjoVBg7JOI0kqR2XZ/W040KfItMuAZ2KM+wDP5O4D9AX2yV3OBW4vw1zS+jbjrG/zls3jd8/8jj1v3pPvDfsew94cxuGtD+fRnzzKN7/5hruOuYverXpbUJIkqRoqaFPA4pWLeX7a81lHKX9HHw0vv5x+rJMkVRtlVlSKMb4AzCky+YfA33K3/wYcmzf93phMBHYIITjojMrHyJGl6vr25jdv0uWuLgx+eTBtm7fl3mPv5dtLvuWBAQ/Qf9/+1KlVp5wCS5KkiujQVodSr1Y9xkwdk3WU8te3L6xeDU89lXUSSVI5Ku+BuneOMX4NkLveKTd9d+CLvOWm56ZtIIRwbghhcghh8syZM8s0rKqBefNg3Lg0QPdGxj0a9sYwetzdg6WrlvLCmS/w+CmPc9r+p9GoTqNyDCtJkiqyerXrcVjrwxj94WhijFnHKV89ekDjxmlcJUlStVFRzv5W3NF8sX+JY4x3xRi7xBi7NG/evIxjqcrbxFnflq5cytmjzuasUWdxcMuDeeO8N+i5R89yDilJkiqLgjYFfDrvU6bMmpJ1lPJVqxYceWQqKlW3gpokVWPlXVT6trBbW+56Rm76dKBl3nItgK/KOZuqowcfhD32KLbr2ydzP6HnPT25+427ueL7VzDu1HHs1GCnYlYiSZKUHL3P0QCM/nB0xkkycPTR8PXX8NZbWSeRJJWT8i4qjQLOyN0+A3g0b/rpIekOzC/sJieVmXnz0lnfBgzYoOvbYx88xoF3Hcin8z7lsZMe49rDrnXwbUmStEl7NN6Djjt3rJ7jKvXJnaNn7Nhsc0iSyk2ZFZVCCPcDE4B9QwjTQwg/A/4MHBFCmAockbsPMBb4BPgI+F9gYFnlktZ69FFYuXK9s76tWrOKy5++nP4P9GfPJnvy+rmvU9CmIMOQkiSpsum3Tz9e+vwl5i6dm3WU8rXLLtC5s+MqSVI1UpZnfzspxrhrjLF2jLFFjPHuGOPsGOPhMcZ9ctdzcsvGGOMFMca9YowdYoyTyyqXtFZh17eDDgLg20XfcuTfj+TPL/+Zczqfw8tnvUzrJq0zDilJkiqbgjYFrI6rGffxuKyjlL++feGVV2BuNSuoSVI1VVEG6pbKV5Gzvr30+UsccOcBTJg+geE/HM5dx9xF3Vp1s04pSZIqoW67d2PHejsyemo1HVdpzRp46qmsk0iSyoFFJVVPua5v8YQTuGnCTfQe3psG2zXg1bNf5YxOZ2z68ZIkSSWoWaMmfffpy+NTH2f1mtVZxylf3bpBkyaOqyRJ1YRFJVVPI0eyYO+WnPDZ9fx63K85Zt9jmHzOZDru3DHrZJIkqQrot08/Zi+dzatfvpp1lPJVsyYcdRQ88URqsSRJqtIsKqn6mTuXd94cR5eTF/HIlEe4/ojr+feJ/6Zx3cZZJ5MkSVXEUXsdRc1QkzEfVsOzwPXtC99+C2+8kXUSSVIZs6ikaufv9w2i209XsbBeDZ4941kuOfgSQghZx5IkSVVIk3pN6LlHT8ZMrYZFpT590rVngZOkKs+ikqqN5auWc/7o8zl99v/SdXYd3rjgHQ75ziFZx5IkSVVUwT4FvPXtW3wx/4uso5SvnXaCLl0sKklSNWBRSdXCtHnT+N6w73HHa3dw6SuBZxpewC6Nds06liRJqsL6tekHwNip1XDQ6qOPhokTYc6crJNIksqQRSVVeWOnjqXznZ35cPaHPNzsQgaPi9Q68SdZx5IkSVVc22Ztab1Da0ZPHZ11lPLXt28aqHvcuKyTSJLKkEUlVVkxRn4//vf0G9GPlo1b8tq5r3HsmI+hVavUJFuSJKkMhRDot08/nvnkGZauXJp1nPLVtSvsuCOMrYattCSpGrGopCrr3rfu5ernr+a0jqcx4WcT2Jum8NRTcMIJ4MDckiSpHBS0KeD/s3fn4VWXd/7/X3f2sCOyCwECCLKvEUEI+4Ekamuxtk7H6djq2A3aaWv7vebbTuc73+/8us1AbW21Y63T6dS6tTYxOWE9oKIsKouCQAKJ7AQI+5rk/v3xSSy1LJF8zrk/55zn47pyHU84eZ/XNeNV4vvc7/d9tu6sVlStcB0ltlJTpdmzpXDYO7EEAEhINJWQkLYd3qYvlH5BU3Km6Kk7n1Kr9FbSSy9JdXVeUwkAACAGpvSZolbprfTy9iS8BW7uXKmmRnrzTddJAABRQlMJCedc3Tl98vlPKjstW7/9+G+VmpLq/cGzzzL6BgAAYiorLUsz+81UyY4SWWtdx4mt2bO90+HcAgcACYumEhLON5d8UxsPbtTTdz2tnu16et88elRaupTRNwAAEHMFAwr0/vH39W7Nu66jxNaNN0rjx7NXCQASGE0lJJSX3ntJj659VKb8gq4AACAASURBVF+99asfXOMrSfrjH73Rt3vucRcOAAAkpbkD5kqSSrYn6S1wa9dKhw+7TgIAiAKaSkgYu4/v1mdf+qzGdB+jf5v+b3/5h02jb2PGOMkGAACSV892PTWq2yi9vCNJ9ypZK5WXu04CAIgCmkpICHUNdfr0i5/WxYaLeuYTzygzLfPPf3jkiLRsmXdKidE3AADgQOHAQq3evVpHzhxxHSW2xoyROndmrxIAJCiaSkgI/7LyX/Tq+6/q8cLH1f+G/n/5h4y+AQAAxwoGFKjBNqi8MslO7KSkSKGQFA5L9fWu0wAAfEZTCXFvxa4V+tdV/6rPjvysPj3s03/9gueek/r2lUaPjn04AAAASeN6jlPnVp2Td6/SkSPS+vWukwAAfEZTCXGt5nSN7nvxPg3sNFCPznn0r19w5Ih36xujbwAAwKEUk6K5A+YqXBFWXUOd6zixNWuWd2KJW+AAIOHQVELcarANuv+P9+vo2aP6/Sd+r9YZrf/6RX/8o3fUet682AcEAAC4ROHAQtWeq9Xru193HSW2OnWS8vLYqwQACYimEuLWwjcWqqyiTD+e9WON6Dbi8i969lmpXz9G3wAAgHMz+81UWkpact4CN2eOtG6ddOiQ6yQAAB/RVEJcWrd3nb619Fu6a9Bd+sK4L1z+RbW13q1v8+Yx+gYAAJxrn9Vek3MmJ+depblzvcfyJFtUDgAJjqYS4s6J8yd07wv3qlubbnryjidlrtQwKivzRt/uvDO2AQEAAK6gYECB3q15V1XHqlxHia1Ro6QuXRiBA4AEQ1MJccVaq4dKHlL1sWr97u7f6YbsG6784uJiqXNnafz42AUEAAC4isKBhZKkl7cn2QhcSoo3Alde7n3oBwBICDSVEFee2vCUnnnnGX0v/3ua2HvilV948aL3SVhBgZSaGruAAAAAVzGw00D1v6F/8u5VOnpUWrvWdRIAgE9oKiFubK3Zqi+XfVnT+k7TtyZ96+ovfvVV6fhxqagoNuEAAACaqXBAoZbvWq7TF067jhJbs2Z5J5ZKS10nAQD4hKYS4sLZi2d17wv3qnV6a/3mY79Raso1Th8VF0sZGd4vLwAAAAFSMLBA5+vPa/mu5a6jxFbHjtKECexVAoAEQlMJceHri7+uTQc36em7nlaPtj2u/mJrvabS1KlSmzaxCQgAANBMk3Mmq01Gm+S9Be7NN6UDB1wnAQD4gKYSAu/FrS/qsfWP6esTvq45A+Zc+we2bZMqKhh9AwAAgZSRmqFZubNUWlEqa63rOLE1p/F3ufJytzkAAL6gqYRAqz5WrQf+9IDG9Rin/zv9/zbvh4qLvcfCwugFAwAAaIHCAYXac2KPNh3c5DpKbI0cKXXvzl4lAEgQNJUQWBfrL+pTL3xKDbZBz3ziGWWkZjTvB4uLpeHDpZyc6AYEAAC4Tk2nr5NuBM4YKRSSFi+W6upcpwEAtBBNJQTWP0f+Wa/veV1PFD6hfh37Ne+HjhyRXnuN0TcAABBo3dp007ge4/TyjpddR4m9uXOlY8ekN95wnQQA0EI0lRBIS3cu1b+9+m/63KjP6ZNDP9n8HywrkxoaaCoBAIDAKxhQoDf2vKGa0zWuo8TWjBlSaiq3wAFAAqCphMA5eOqgPvOHz2jQjYO0aM6ij/bDxcVS167SuHHRCQcAAOCTwoGFsrIKV4RdR4mtDh2kiRPZqwQACYCmEgKlwTbo/j/er9qztfr9J36vVumtmv/DFy5I4bBUUCCl8K82AAAItlHdR6lbm24q2ZFke5Uk7xa4DRukfftcJwEAtAD/5Y1A+fHqH6u8slwLQws1rOuwj/bDr7winTjB6BsAAIgLKSZFBQMKVF5Rrov1F13Hia25c73HcJKd0gKABENTCYGxZs8a/a/l/0t3D75bD4156KMXKC6WMjOlmTP9DwcAABAFBQMKdPz8cb22+zXXUWJr2DCpZ0/2KgFAnKOphEA4fu64PvXCp9SzbU/9suiXMsZ8tALWek2ladOk1q2jExIAAMBnM/rNUEZqhl7enmS3wBnjjcAtXixdTLJTWgCQQGgqIRAeKnlI7x9/X7+7+3fqmN3xoxfYulXauZPRNwAAEFfaZrbVlJwpybtX6cQJ6fXXXScBAFwnmkpwbu3etfr9u7/Xd6Z8RxN6Tbi+IsXF3mNhoX/BAAAAYqBwYKHeO/yeKo9Wuo4SWzNmSGlpjMABQByjqQTnFq1ZpHaZ7fTVW796/UWKi6WRI6VevfwLBgAAEAMFAwokSS/vSLIRuHbtpEmTpNJS10kAANfpqk0lY8wEY8zPjDGbjDE1xpj3jTGlxpgvGmPaxyokEtfeE3v17LvP6oFRD6htZtvrK3L4sHdsmtE3AAAQh3JvyNXNnW5OvqaS5N0Ct2mTtHev6yQAgOtwxaaSMaZM0ucklUsKSeou6RZJ/yQpS9JLxpg7YhESievn63+u+oZ6fWn8l66/SFmZ1NBAUwkAAMStwoGFilRFdOrCKddRYmvOHO+RETgAiEtXO6n0GWvtA9baP1lr91lr66y1p6y1b1lrf2ytzZe0OkY5kYDOXjyrX6z/he4cdKf6dex3/YWKi6Vu3aQxY/wLBwAAEEMFAwp0of6Clu5c6jpKbA0Z4q0voKkEAHHpik0la+1hSTLGtDbGpDT+80BjzB3GmPRLXwNcj//Z/D86cvaI5ufNv/4iFy5I4bC3oDuFFWEAACA+Teo9Se0y26lke5LdAmeMd1ppyRLv9zoAQFxpzn+Fr5KUZYzpKWmZpM9K+nU0QyHxWWu1cM1Cjeg6QlNyplx/oVWrpJMnGX0DAABxLT01XbNzZ6t0R6kabIPrOLE1d673+9xqhiAAIN40p6lkrLVnJH1c0qPW2o/J260EXLcVVSv0zqF3tODWBTLGXH+h4mIpK8u7khYAACCOFQ4s1P5T+/X2/rddR4mtadOk9HRugQOAONSsppIxZoKk+yQ1XUmRFr1ISAYL31iozq06696h915/EWu9ptL06VKrVv6FAwAAcGBO/zkyMsl3C1zbttLkyexVAoA41Jym0gJJ35b0B2vtu8aYfpJWRDcWElnF0QqVbC/Rw2MfVlZa1vUX2rJF2rWL0TcAAJAQOrfurLyb8pJvr5Lk7VV65x1p927XSQAAH8E1m0rW2pXW2justd9vfL7TWvuV6EdDonp0zaNKS0nTw+Meblmh4mLvsbCw5aEAAAACoGBAgdbtW6eDpw66jhJbc+Z4j5xWAoC4cs2mkjFmrDHmRWPMW8aYTU1fsQiHxHP83HH9asOvdO/Qe9WtTbeWFSsulkaPlnr29CccAACAY4UDvQ/LSnck2X6hwYOlnBz2KgFAnGnO+Ntv5d32drekoku+gI/sqQ1P6dSFU5qfN79lhWpqpNdfZ/QNAAAklBFdR6hn257Jt1fJGO+00rJl0vnzrtMAAJqpOU2lGmvtn6y1u6y11U1fUU+GhFPfUK+frPmJJvWepDE9xrSsWGmpt6ibphIAAEggxhgVDCjQ4srFulB/wXWc2Jo7Vzp1Snr1VddJAADN1Jym0neNMf9pjPmUMebjTV9RT4aEU7y9WLuO7dKCvAU+FCuWevTwxt8AAAASSMHAAp28cFKvVL/iOkpsTZsmZWSwVwkA4khzmkqflTRSUkh/Hn1jMzI+skVrFql3+966c9CdLSt0/rxUXu4t6DbGn3AAAAABMb3vdGWmZqqsIsmaK61bS1OmsFcJAOJIWjNeM8JaOyzqSZDQNhzYoEhVRD+c+UOlpTTnX7urWLnSOxrN6BsAAEhArTNaa0KvCVpRtcJ1lNibM0f62tek6mpvcTcAINCac1LpDWPMLVFPgoT2kzU/Uav0Vnpg1AMtL1ZcLGVnS9Ont7wWAABAAOXn5Ovt/W/r2LljrqPE1ty53iMjcAAQF5rTVJokaYMxZpsxZpMxZrMxZlNL3tQY81VjzLvGmHeMMb8zxmQZY/oaY9YYY3YYY35vjMloyXsgOA6dPqTfbv6t/m7E36ljdseWFbPWayrNmOE1lgAAABJQfp98Wdnk26s0cKDUty8jcAAQJ5rTVApJGiBplv68T+m6546MMT0lfUXSWGvtUEmpku6V9H1J/2GtHSCpVpIPR1oQBI+vf1wX6i/oK3lfaXmxd97xjkMz+gYAABJY3k15ykzNVKQq4jpKbBnjnVZatszbowkACLTmNJW6Szpqra221lZLOiqpWwvfN01StjEmTVIrSfslTZP0fOOfPy3prha+BwLgfN15Pbb+Mc3pP0c333hzywsWF3uPheyKBwAAiSsrLUu39botefcqnTkjrVrlOgkA4Bqa01T6uaRTlzw/3fi962Kt3SvpR5Lel9dMOi7pTUnHrLV1jS/bI6nn5X7eGPOgMWa9MWZ9TU3N9cZAjDz77rM6cOqAFty6wJ+CxcXS2LFS9+7+1AMAAAio/D752nBgg2rP1rqOEltTp0qZmexVAoA40JymkrHW2qYn1toGNe/WuMsXM6ajpDsl9ZXUQ1JrSXMu81J7me/JWvuEtXastXZs586drzcGYsBaq4VrFmrwjYM1s9/Mlhc8dEhas4bRNwAAkBQ+2Kv0fpLtVWrVSsrPZ68SAMSB5jSVdhpjvmKMSW/8mi9pZwvec4akXdbaGmvtRUkvSrpNUofGcThJuknSvha8BwLgtd2v6a39b2l+3nwZY1pe8OWXvUXdNJUAAEASyOuZp6y0rOTbqyR5e5W2bZN2tuQ/OwAA0dacptI/yGv67JU3lpYn6cEWvOf7km41xrQyXqdhuqQtklZI+kTja+6X9FIL3gMBsGjNInXM6qjPjPiMPwWLi6WbbpJGjvSnHgAAQIBlpmXqtl63JW9TSfI+VAQABNY1m0rW2kPW2nuttV2stV2ttZ+21h663je01q6Rt5D7LUmbGzM8IekRSV8zxlRI6iTpyet9D7hXfaxaL259UQ+OeVCt0lu1vOC5c9Lixd6Cbj9OPQEAAMSB/Bxvr9LRs0ddR4mt/v2lm2/+8yUtAIBAumJTyRjzT8aYG67y59OMMdd1BZe19rvW2kHW2qHW2s9Ya89ba3daa8dba/tba+dZa7lDNI79bN3PZGT0xXFf9KdgJCKdPs3oGwAASCof7FWqTrK9SpL3e18kIp044ToJAOAKrnZSabOkYmPMMmPMD40x3zTGfMcY8xtjzGZJRZLWxCYm4smpC6f0y7d+qbtvuVu92vfyp2hxsbe0cdo0f+oBAADEgfE9xyfvXqWiIuniRe+0OgAgkK7YVLLWvmStnShvp9K7klIlnZD035LGW2u/aq2tiU1MxJP/2vhfOnbumBbkLfCnoLVeU2nmTCkry5+aAAAAceCDvUrVEddRYu+226SOHRmBA4AAS7vWC6y1OyTtiEEWJIAG26CfrPmJxvUYp1tvutWfops2Sbt3S9/9rj/1AAAA4sjUPlP1nRXf0dGzR3VD9hW3UySetDRvYXdpqVRfL6Wmuk4EAPiQ5tz+BjRbeUW5th3ZpgW3LpDxa6F206dTBQX+1AMAAIgjTXuVVlWvch0l9oqKpMOHpTfecJ0EAHAZNJXgq0VrFql7m+76xC2f8K9ocbE0frzUrZt/NQEAAOLEuB7jlJ2WnZx7lUIh78QSI3AAEEg0leCbrTVbVV5Zri+O+6IyUjP8KXrggLR2Lbe+AQCApPXBXqVkbCq1by9NnkxTCQAC6ppNJWPMwMYb4N5pfD7cGPNP0Y+GePOTNT9RVlqWHhzzoH9FX37Ze6SpBAAAklh+n3xtPLhRR84ccR0l9oqKpC1bpJ07XScBAHxIc04q/VLStyVdlCRr7SZJ90YzFOLP0bNH9fTGp3XfsPvUuXVn/woXF0u9eknDh/tXEwAAIM5M7TNVkpJ3r5LEaSUACKDmNJVaWWvXfuh7ddEIg/j1yzd/qbN1ZzU/b75/Rc+dk5Ys8X6R8GvpNwAAQBwa1zOJ9yrl5kqDB9NUAoAAak5T6bAxJleSlSRjzCck7Y9qKsSVi/UX9dN1P9W0vtM0rOsw/wovXy6dOcPoGwAASHoZqRma2HuiItUR11HcKCqSVq6Ujh93nQQAcInmNJW+KOlxSYOMMXslLZD0cFRTIa784b0/aM+JPVqQt8DfwsXFUuvWUn6+v3UBAADiUH5OvjYd3JS8e5Xq6qTyctdJAACXuGZTyVq701o7Q1JnSYOstZOstVVRT4a4sWjNIuV2zFXBwAL/ilorlZRIs2ZJWVn+1QUAAIhTU/t6e5VWVq90nMSBCROkTp283w8BAIGRdq0XGGO+9qHnknRc0pvW2g1RyoU4sXbvWq3evVqLQouUYppz8K2ZNmyQ9uyR/uVf/KsJAAAQx8b2GKtW6a0UqYro44M/7jpObKWmSnPnSqWlUn299xwA4FxzugBjJf2DpJ6NXw9Kypf0S2PMN6MXDfFg0ZpFapfZTp8d+Vl/CxcXe8u5C3w8/QQAABDHMlIzNLHXxORc1i15I3BHjkivv+46CQCgUXOaSp0kjbbW/qO19h/lNZk6S5os6e+imA0Bt+/kPj377rP6+5F/r7aZbf0tXlws5eVJXbr4WxcAACCO5ffJ1+ZDm3X4zGHXUWJv9mwpPZ1b4AAgQJrTVOot6cIlzy9KyrHWnpV0PiqpEBceW/eY6hvq9eW8L/tbeN8+af16qbDQ37oAAABxLr9PviRpZVUS7lVq106aMoWmEgAESHOaSv8j6Q1jzHeNMd+V9Jqk3xljWkvaEtV0CKyzF8/q8Tcf1x0336F+Hfv5W/zll73HoiJ/6wIAAMS5cT3GfbBXKSkVFUlbt0qVla6TAADUvNvf/o+kz0s6Jm9B9z9Ya//FWnvaWntftAMimP5n8//o8JnDWnDrAv+LFxdLvXtLw4b5XxsAACCOpaema1LvSYpUR1xHcaPpQ0dOKwFAIFy1qWSMSTHGvGOtfdNau8hau9Bauz5W4RBM1lotWrNII7qO0JScKf4WP3tWWrrU+4XBu2kQAAAAl8jPydc7h95Rzeka11Fir29facgQmkoAEBBXbSpZaxskbTTG9I5RHsSBFVUrtPnQZs3Pmy/jd+Nn2TKvscToGwAAwGV9sFepOgn3Kkne74mrVknHj7tOAgBJrzk7lbpLetcYs8wY86emr2gHQ3AtfGOhOrfqrE8N+5T/xYuLpTZtpPx8/2sDAAAkgLE9xqp1euvk3qtUVyeFw66TAEDSS2vGa74X9RSIGxVHK1SyvUT/NPmflJWW5W9xa6WSEmnWLCkz09/aAAAACeKDvUrJ2lTKy5NuvNH7MPKTn3SdBgCS2jWbStbaJD1Xi8t5dM2jSktJ08NjH/a/+FtvSfv2MfoGAABwDfl98vXtZd/WodOH1KV1F9dxYis1VSookP70J+/EUlpzPicHAETDNcffjDG3GmPWGWNOGWMuGGPqjTEnYhEOwXLm4hk9teEpfXLoJ9W9bXf/36C42FvOPXeu/7UBAAASSNNepVXVq9wGcaWoSKqtlVavdp0EAJJac3Yq/VTSpyTtkJQt6XON30OSiVRFdPLCSf3t8L+NzhsUF0u33ip1SbJP2wAAAD6iMd3HqHV6a63YtcJ1FDdmzZIyMrgFDgAca05TSdbaCkmp1tp6a+1TkvKjmgqBFK4IKzstW7fn3O5/8b17vfE3Rt8AAACuKT01Xbfn3K5IdcR1FDfatvUudqGpBABONaepdMYYkyFpgzHmB8aYr0pqHeVcCKBwRVhT+071f0G35C3olmgqAQAANFN+Tr621GzRodOHXEdxo6hI2rZN2rHDdRIASFrNaSp9pvF1X5J0WlIvSXdHMxSCp/JopXYc3aFQbig6b1BcLPXpIw0ZEp36AAAACaZpr9LKqiS9V6fpw0hOKwGAM9dsKllrq62156y1J6y137PWfq1xHA5JpLyyXJIU6h+FptKZM9KyZd4vBsb4Xx8AACABje4+Wm0y2mhFVZLuVcrJkYYNo6kEAA415/a3icaYJcaY7caYnU1fsQiH4AhXhNWvYz/1v6G//8UjEencOamw0P/aAAAACSo9NV2Tek9SpCriOoo7RUXSK694N8EBAGKuOeNvT0r6d0mTJI275AtJ4nzdeS3ftVyh3JBMNE4SlZZKrVpJkyf7XxsAACCBTe0zVVsPb9XBUwddR3GjqEiqr5fCYddJACApNaepdNxaW2atPWStPdL0FfVkCIzXdr+m0xdPR2f0zVqprEyaNk3KisICcAAAgAT2wV6l6iTdqzR+vNSlCyNwAODIFZtKxpjRxpjRklYYY35ojJnQ9L3G7yNJhCvCSk9J19S+U/0vvn27tHOnNGeO/7UBAAAS3Ad7lXYl6V6llBSpoMD7kPLiRddpACDppF3lz378oedjL/lnK2ma/3EQROGKsG7PuV1tMtr4X7yszHukqQQAAPCRpaWk6fbetytSHXEdxZ2iIumpp6TXXpPy812nAYCkcsWmkrU2CsdSEG/2ntirzYc26wczfhCdNygtlQYNkvr2jU59AACABDe1z1SVLS3TgVMH1K1NN9dxYm/mTCkjwxuBo6kEADHVnNvf/p8xpsMlzzsaY/41urEQFIsrF0tSdPYpnT4trVwpzZ3rf20AAIAk8cFepaok3avUpo23n5O9SgAQc81Z1D3HWnus6Ym1tlYSXYAkEa4Mq0fbHhraZaj/xZcvly5cYPQNAACgBUZ1H6W2GW0VqYq4juJOUZG0Y4e0bZvrJACQVJrTVEo1xmQ2PTHGZEvKvMrrkSDqGuq0pHKJQrkhGWP8f4OyMql1a+n22/2vDQAAkCTSUtJ0e87tWlGVpMu6Jamw0HvktBIAxFRzmkr/LWmZMeYBY8zfS1oi6enoxkIQrNu7TrXnaqMz+matt09p+nQpkx4lAABAS+Tn5GvbkW3af3K/6yhu9O4tjRhBUwkAYuyaTSVr7Q8k/aukwZKGSPo/jd9DggtXhJViUjSj3wz/i7/3nlRdzT4lAAAAH0zt692xs7I6SfcqSd4I3GuvSUePuk4CAEmjOYu6W0tabK39uqQnJGUaY9KjngzOhSvDyuuZp47ZHf0vXlrqPbJPCQAAoMVGdhupdpnt2KtUX++tWAAAxERzxt9WScoyxvSUtFTSZyX9Opqh4N7hM4e1bu+66Iy+Sd5f9kOGeEeVAQAA0CJpKWm6vXeS71UaO1bq1o0ROACIoeY0lYy19oykj0t61Fr7MUm3RDcWXFtSuURWNjpNpZMnpVWrOKUEAADgo/w++dp+ZLv2ndznOoobKSlSQYEUDksXL7pOAwBJoVlNJWPMBEn3SXq58Xtp0YuEIAhXhtUpu5PGdB/jf/Hly72/6GkqAQAA+Ca/T74kaWVVku9VOn5ceuUV10kAICk0p6m0QNK3Jf3BWvuuMaafpCQ+V5v4GmyDyivKNSt3llJTUv1/g7IyqU0badIk/2sDAAAkqVHdRrFXacYM72ZhRuAAICaac/vbSmvtHdba7zc+32mt/Ur0o8GVjQc26uDpg9EZfbPWW9I9Y4aUkeF/fQAAgCSVmpKqyTmTk3uvUuvW0vTpXlPJWtdpACDhXbGpZIxZ2PhYbIz504e/YhcRsRauCEuSZuXO8r/4li3S7t3S3Ln+1wYAAEhy+Tn52nF0h/ae2Os6ijtFRVJlpfTee66TAEDCu9pupN80Pv4oFkEQHOHKsEZ1G6Vubbr5X7y01HtknxIAAIDvPtirVL1Snx72abdhXCkslB5+2DutNHiw6zQAkNCueFLJWvtm4+NKSVskbWkchVvZ+D0koOPnjmv17tXRGX2TvH1Kw4ZJN90UnfoAAABJbGS3kWqf2T659yrddJM0ahR7lQAgBq42/maMMf9sjDks6T1J240xNcaY78QuHmJt+a7lqmuoi05T6cQJ7yYOTikBAABERdNepaRuKkneCNzq1dKRI66TAEBCu9qi7gWSJkoaZ63tZK3tKClP0kRjzFdjkg4xF64Iq21GW024aYL/xZctk+rq2KcEAAAQRfl92KukwkKpoeHPqxcAAFFxtabS30r6lLV2V9M3rLU7Jf1N458hwVhrFa4Ma0a/GUpPTff/DUpLpXbtpNtu8782AAAAJP15r1JSn1YaM0bq1o0ROACIsqs1ldKttYc//E1rbY2kKHQc4Nq2I9v0/vH3ozP6Zq23T2nmTCmdf30AAACiZUTXEeqQ1SG5m0opKd5ppXBYunDBdRoASFhXaypd7X99+V/mBBSuCEuSZufO9r/45s3S3r3sUwIAAIiyD/YqVUdcR3GrqEg6eVJatcp1EgBIWFdrKo0wxpy4zNdJScNiFRCxE64Ia/CNg5XTIcf/4mVl3iNNJQAAgKjLz8lXxdEK7Tmxx3UUd2bMkLKyGIEDgCi6YlPJWptqrW13ma+21lrmlxLM2YtntbJ6ZXRG3yRvn9KIEVKPHtGpDwAAgA+wV0lSq1bS9OleU8la12kAICFd7aQSksjK6pU6V3cuOqNvx49Lr73GrW8AAAAxMrzrcPYqSd4I3K5d0pYtrpMAQEKiqQRJ3uhbVlqWJudM9r/4kiVSfT2jbwAAADGSmpKqKTlTaCoVFnqPjMABQFQ4aSoZYzoYY543xrxnjNlqjJlgjLnBGLPEGLOj8bGji2zJKlwRVn6ffGWnZ/tfvKxMat9emjDB/9oAAAC4rPw++aqsrdTu47tdR3GnZ09p9GiaSgAQJa5OKi2SFLbWDpI0QtJWSd+StMxaO0DSssbniIFdtbu07cg2hXKjsE/JWq+pNGuWlJbmf30AAABcFnuVGhUVSa+/LtXUuE4CAAkn5k0lY0w7SZMlPSlJ1toL1tpjku6U9HTjy56WdFessyWr8spySYrOku6NG6X9+9mnBAAAEGPDuw5Xx6yONJWKirwPOktLXScBgITj4qRSP0k1kp4yxrxtjPlPY0xrSV2ttfslqfGxy+V+2BjzoDFmvTFmfQ2fNvgiXBFWnw59NLDTQP+LN/3lHYrSrXIAvoBi5wAAIABJREFUAAC4rBSTosk5kxWpjriO4tbo0d4NxIzAAYDvXDSV0iSNlvRza+0oSaf1EUbdrLVPWGvHWmvHdu7cOVoZk8aF+gtatmuZQrkhGWP8f4OyMu8v8m7d/K8NAACAq5raZ6p21u7U+8ffdx3FHWO8hd3l5dL5867TAEBCcdFU2iNpj7V2TePz5+U1mQ4aY7pLUuPjIQfZks7q3at16sKp6Iy+1dZKq1dz6xsAAIAj7FVqVFQknTolrVzpOgkAJJSYN5WstQck7TbG3Nz4remStkj6k6T7G793v6SXYp0tGYUrwkpLSdO0vtP8L75kidTQwD4lAAAAR4Z1HcZeJUmaPl3KzmYEDgB85ur2ty9L+q0xZpOkkZL+n6T/T9JMY8wOSTMbnyPKwhVhTeo9SW0z2/pfvLRU6thRysvzvzYAAACuKcWkaEqfKTSVsrOlGTO8ppK1rtMAQMJw0lSy1m5o3Is03Fp7l7W21lp7xFo73Vo7oPHxqItsyWTfyX3aeHCjQrlRGH1raJDCYWn2bCk11f/6AAAAaJb8nHztOrZL1ceqXUdxq6hIqq6W3nnHdRIASBiuTiohABZXLpak6OxTevtt6eBB9ikBAAA4NrXvVEnsVVJhoffICBwA+IamUhIrryxXtzbdNLzrcP+Ll5V5j6EoNKwAAADQbEO7DNUN2TcoUh1xHcWt7t2lsWNpKgGAj2gqJan6hnotrlysUP+QjDH+v0FpqfeXdpcu/tcGAABAs6WYFE3JYa+SJG8Ebs0a6RAXTQOAH2gqJan1+9br6Nmj0dmndOSI95c1t74BAAAEQn6ffFUdq1LVsSrXUdy64w5vUTenlQDAFzSVklS4Iiwjoxn9ZvhffPFib1E3+5QAAAACYWof9ipJkkaMkPr1k557znUSAEgINJWSVLgyrPE9x6tTq07+Fy8rkzp1ksaN8782AAAAPrIhXYaoU3YnmkrGSPfcIy1d6p2uBwC0CE2lJHTkzBGt3bs2Ore+NTRI4bA0e7aUmup/fQAAAHxkKSZFU/qwV0mSNG+eVF8v/fGPrpMAQNyjqZSElu5cqgbbEJ2m0ptvSjU1jL4BAAAETH5OvqqPV7NXadQoKTdXevZZ10kAIO7RVEpC4cqwOmZ11LgeURhPKyvzjhXPnu1/bQAAAFy3/D75ktirJGO800rLlkmHD7tOAwBxjaZSkrHWKlwR1qzcWUpNicJ4Wmmpt0upc2f/awMAAOC6DekyRJ1bddbSnUtdR3HvnnsYgQMAH9BUSjKbDm7SgVMHojP6dviwtHatNHeu/7UBAADQIikmRTNzZ2px5WI12AbXcdwaOZIROADwAU2lJBOuCEuSZudGYTytvFyyln1KAAAAARXKDanmTI3e3v+26yhuNd0Ct3w5I3AA0AI0lZJMuDKsEV1HqHvb7v4XLyvzxt7GjvW/NgAAAFpsVu4sSX/+oDGpNd0C94c/uE4CAHGLplISOXn+pF59/9XojL7V10vhsLegO4V/rQAAAIKoa5uuGt19tMKVNJU0cqTUv7/03HOukwBA3OK//pPI8l3LVddQF52m0vr10pEj7FMCAAAIuFBuSK/vfl3Hzh1zHcUtRuAAoMVoKiWRcEVYbTLa6LZet/lfvLTUO6E0a5b/tQEAAOCbUP+Q6m29lu1c5jqKe4zAAUCL0FRKEtZahSvDmt53ujJSM/x/g7IyKS9P6tTJ/9oAAADwza033ap2me3YqyRJI0ZIAwZwCxwAXCeaSklix9EdqjpWFZ3Rt0OHpHXruPUNAAAgDqSnpmtGvxkKV4ZlrXUdxy1jvNNKK1ZINTWu0wBA3KGplCSaPomanTvb/+Ll5d4j+5QAAADiQig3pD0n9mhLzRbXUdy75x5G4ADgOtFUShLhirBu7nSz+nbs63/x0lKpSxdp1Cj/awMAAMB3s/t7HzQyAidp+HBG4ADgOtFUSgJnL55VpCoSnVNK9fXeSaU5c7xF3QAAAAi83u1765bOtyhcSVPpg1vgGIEDgI+MLkASeOX9V3S27mx09imtWSPV1rJPCQAAIM6EckNaVb1Kpy+cdh3FvXnzpIYG6cUXXScBgLhCUykJhCvCykzN1JQ+U/wvXlbmnVCaNcv/2gAAAIiaUP+QLtRf0Mrqla6juDd8uDRwoPTcc66TAEBcoamUBMIVYU3pM0Wt0lv5X7y0VJowQerY0f/aAAAAiJrbc25Xdlo2e5Wkv7wF7tAh12kAIG7QVEpw1ceqtfXwVoVyozD6duCA9NZb3PoGAAAQh7LSsjS171SaSk3uuccbgeMWOABoNppKCa68slySorNPKdz4Cwj7lAAAAOJSKDekHUd3qPJopeso7g0b5o3AcQscADQbTaUEF64Iq3f73hp04yD/i5eVSd27SyNH+l8bAAAAUTe7v3c7cNMHkUmt6Ra4SIQROABoJppKCexi/UUt3blUodyQjDH+Fq+rkxYvlkIh7y9gAAAAxJ0BNwxQ3w59GYFr0jQCxy1wANAsNJUS2Ot7XtfJCyejM/r2xhvSsWPsUwIAAIhjxhiF+oe0fNdyna877zqOe0OHSjffzC1wANBMNJUSWLgirLSUNE3rO83/4qWlUmqqNGOG/7UBAAAQM6H+IZ2+eFqv7X7NdRT3Lh2BO3jQdRoACDyaSgmsvLJcE26aoPZZ7f0vXlYmTZwodejgf20AAADEzNQ+U5Weks4IXJN58xiBA4BmoqmUoI6dO6a397+t6X2n+1983z5pwwZufQMAAEgAbTPbalLvSTSVmgwdKg0axAgcADQDTaUE9Ur1K7Kyyu+T73/xcOMvHOxTAgAASAih/iFtPrRZe0/sdR3FPWO800orVzICBwDXQFMpQa2oWqHM1Ezl3ZTnf/HSUqlnT2nYMP9rAwAAIOaaLnYpryx3nCQguAUOAJqFplKCilRFdFuv25SVluVv4YsXpSVLvNE3Y/ytDQAAACeGdRmm7m2601RqMmSINwL37LOukwBAoNFUSkC1Z2u14cCG6Iy+rV4tnTjBPiUAAIAEYoxRqH9ISyqXqK6hznUc95pugVu1SjpwwHUaAAgsmkoJ6JX3o7hPqaxMSkuTZszwvzYAAACcCfUPqfZcrdbtXec6SjBwCxwAXBNNpQS0YtcKZaVlKa9nFPYplZVJkyZJ7dr5XxsAAADOzOg3QykmhVvgmgwZIg0ezC1wAHAVNJUSUKTa26eUmZbpb+E9e6RNmxh9AwAASEA3ZN+gvJ55ClfSVJL05xG4lSsZgQOAK6CplGCOnj2qjQc2Kj8n3//iL7/sPRYW+l8bAAAAzoX6h7Ru7zodPnPYdZRgmDdPslZ64QXXSQAgkGgqJZhXqqO4T6m4WOrb1zsGDAAAgIQT6h+SldWSyiWuowTDkCHSLbcwAgcAV0BTKcFEqiLKSsvS+J7j/S185oy0bJl3SskYf2sDAAAgEMZ0H6NO2Z0YgbvUvHneLXD797tOAgCBQ1MpwayoWqGJvSb6v09p+XLp3DmpqMjfugAAAAiM1JRUzcydqfKKcjXYBtdxgqFpBI5b4ADgr9BUSiBHzx7VpoObojP6VlIitWkjTZ7sf20AAAAERig3pIOnD2rjgY2uowRD0wjcs8+6TgIAgUNTKYGsql4VnX1K1npNpVmzpEyfT0ABAAAgUGblzpIkhSsYgfvAPfdIr7zCCBwAfAhNpQQSqYooOy1b43qM87fwxo3S3r3c+gYAAJAEurftrpHdRrJX6VLcAgcAl0VTKYGsqFqh23rd5v8+pZIS73HuXH/rAgAAIJBCuSGt3r1aJ86fcB0lGG65xRuD4xY4APgLNJUSxJEzR7Tp4CZN7TPV/+IlJdL48VLXrv7XBgAAQOCE+odU11Cn5buWu44SHPPmMQIHAB9CUylBrKpeJUn+71M6eFBau5bRNwAAgCQyodcEtc1oy16lSzECBwB/haZSgvhgn1JPn/cplZV5f3nSVAIAAEgaGakZmt5vusIVYVlrXccJhltukYYO5RY4ALgETaUEsaJqhSb2nqiM1Ax/CxcXSz17SiNH+lsXAAAAgRbKDan6eLW2HdnmOkpwzJsnvfqqtG+f6yQAEAg0lRLA4TOHtfnQZv/3KZ0/Ly1e7J1SMsbf2gAAAAi02f1nSxIjcJdiBA4A/gJNpQQQtX1Kq1ZJp04x+gYAAJCE+nToo0E3DqKpdKnBgxmBA4BL0FRKAJGqiFqlt9LYHmP9LVxSImVlSdOm+VsXAAAAcSGUG9LK6pU6e/Gs6yjBcc890muvSXv3uk4CAM7RVEoAkaqIJvbyeZ+Std4+penTpVat/KsLAACAuBHqH9K5unNaWb3SdZTgYAQOAD5AUynO1Zyu0eZDm/0ffXvvPWnXLkbfAAAAktjknMnKSstiBO5SgwZJw4ZJzz3nOgkAOEdTKc417VPyfUl3SYn3WFDgb10AAADEjez0bOX3yaep9GFNt8AxAgcgyTlrKhljUo0xbxtjShqf9zXGrDHG7DDG/N4Y4+MsV+KK6j6lESOkXr38rQsAAIC4EsoNaduRbdpVu8t1lOCYN897ZAQOQJJzeVJpvqStlzz/vqT/sNYOkFQr6QEnqeJMpDqiSb0nKT013b+iR496ywcZfQMAAEh6s/vPliSVV5Y7ThIgTSNw3AIHIMk5aSoZY26SVCDpPxufG0nTJD3f+JKnJd3lIls8qTldo3cOvaP8nHx/C5eXS/X1NJUAAACgmzvdrJz2OTSVPoxb4ADA2UmlhZK+Kamh8XknScestXWNz/dI6nm5HzTGPGiMWW+MWV9TUxP9pAHWdAvH1L5R2KfUubM0bpy/dQEAABB3jDEK9Q9p2c5lulB/wXWc4GgagXv++au/DgASWMybSsaYQkmHrLVvXvrty7zUXu7nrbVPWGvHWmvHdu7cOSoZ40WkKqLW6a01pvsY/4rW1UllZd6C7tRU/+oCAAAgboX6h3Tywkm9vvt111GC4+abpeHDGYEDkNRcnFSaKOkOY0yVpGfkjb0tlNTBGJPW+JqbJO1zkC2uRKqisE9p9WqptpbRNwAAAHxgWt9pSktJ4xa4D7vnHu/35z17XCcBACdi3lSy1n7bWnuTtbaPpHslLbfW3idphaRPNL7sfkkvxTpbPDl0+pDerXlX+X3y/S1cUiKlp0szZ/pbFwAAAHGrXWY7Tew1UeFKmkp/gRE4AEnO5e1vH/aIpK8ZYyrk7Vh60nGeQFtZ5e1TikpTacoUqV07f+sCAAAgroX6h7ThwAbtP7nfdZTgGDhQGjFCeu4510kAwAmnTSVrbcRaW9j4zzutteOttf2ttfOsteddZgu6SFVEbTLa+LtPqbJS2rqV0TcAAAD8lVD/kCRpceVix0kCpmkEbvt210kAIOaCdFIJH0GkOgr7lF5+2XukqQQAAIAPGdF1hLq16cYI3Ic98ICUmSn96EeukwBAzNFUikOHTh/Slpotys/J97dwSYk0aJCUm+tvXQAAAMQ9Y4xm587W4srFqm+odx0nOLp2lf7u76Snn5b2MxoIILnQVIpDkaqIJJ/3KZ08KUUinFICAADAFYX6h3T07FGt37fedZRg+frXpbo6adEi10kAIKZoKsWhD/Yp9fBxn9KSJdLFizSVAAAAcEUz+82UkVG4ghG4v9C/v3T33dLPfy4dP+46DQDEDE2lOBSpiuj23rcrLSXNv6IlJVKHDtLEif7VBAAAQELp1KqTxvccz16ly3nkEenECenxx10nAYCYoakUZw6eOqith7f6O/rW0OAt6Z4zR0rzsVEFAACAhBPqH9LavWt19OxR11GCZcwYacYMaeFC6TwXWQNIDjSV4kxU9imtWycdOsToGwAAAK4p1D+kBtugpTuXuo4SPI884i3r/s1vXCcBgJigqRRnIlURtc1oq9HdR/tXtKRESkmRQiH/agIAACAhjesxTh2zOrJX6XKmT5dGj5Z++EOpnhvyACQ+mkpxJlId0e05UdinNHGidMMN/tUEAABAQkpNSdWs3FkKV4RlrXUdJ1iM8U4rbd8uvfSS6zQAEHU0leLIgVMH9N7h95Sfk+9f0T17pA0bGH0DAABAs83Ona39p/Zr86HNrqMEz913S7m50ve/L9F0A5DgaCrFkajsU3r5Ze+RphIAAACaaXb/2ZLECNzlpKZKX/+6tHattHKl6zQAEFU0leJI0z6lUd1H+Ve0pETq21caPNi/mgAAAEhoPdr20PCuw2kqXcn990tduninlQAggdFUiiORqogm50z2b5/SmTPS0qXeKSVj/KkJAACApBDKDenV91/VyfMnXUcJnuxsaf58KRyWNm50nQYAooamUpzYf3K/th3Z5u/o24oV0rlzjL4BAADgIwv1D+liw0WtqFrhOkowPfyw1KaN9IMfuE4CAFFDUylOrKz25rF9bSqVlHh/0U2Z4l9NAAAAJIWJvSeqdXprRuCupGNH6aGHpGeekXbtcp0GAKKCplKcWLFrhdplttPIbiP9KWit11SaNUvKzPSnJgAAAJJGRmqGpvebrrKKMlluObu8r37VW9z94x+7TgIAUUFTKU5EqiO6vfft/u1T2rhR2rOH0TcAAABct1BuSFXHqrT9yHbXUYKpZ0/pb/5G+tWvpJoa12kAwHc0leLAvpP7tP3Idk3tM9W/oiUl3uPcuf7VBAAAQFIpHFioFJOiX2/4tesowfWNb0hnz0qPPuo6CQD4jqZSHFhZFaV9SuPHS127+lcTAAAASaVX+1762KCP6fE3H9eZi2dcxwmmwYOlO++UfvpT6dQp12kAwFc0leLAiiqf9ykdPCitXcvoGwAAAFpsft581Z6r1X9v+m/XUYLrkUek2lrpP//TdRIA8BVNpTgQqYpocs5kpaak+lOwrMxb1E1TCQAAAC00qfckje4+WgvfWMjC7iuZMEG6/Xbp3/9dunjRdRoA8A1NpYDbe2Kvdhzd4f8+pR49pJE+nXwCAABA0jLGaEHeAm09vFVLdi5xHSe4HnlE2r1b+t3vXCcBAN/QVAq4ldU+71O6cEEqL/dOKRnjT00AAAAktXuG3KOurbtq0ZpFrqME19y50tCh0g9+IDU0uE4DAL6gqRRwK3atUPvM9hrRdYQ/BVet8hYEFhX5Uw8AAABJLzMtU18Y9wWV7ijVtsPbXMcJJmOkb35TevddqbTUdRoA8AVNpYCLVPu8T6mkRMrKkqZN86ceAAAAIOmhMQ8pIzVDj6591HWU4Lr3Xql3b+n733edBAB8QVMpwPac2KOKoxX+jb5ZKxUXS9OnS61a+VMTAAAAkNS1TVd9etin9dSGp1R7ttZ1nGBKT5f+8R+lV1+VVq92nQYAWoymUoCtrPL2Kfm2pHvbNmnnTm59AwAAQFTMz5uvMxfP6Mm3n3QdJbgeeEDq1InTSgASAk2lAItURdQhq4OGdx3uT8HiYu+xoMCfegAAAMAlRnYbqSk5U/TTtT9VXUOd6zjB1Lq19KUvSX/6k7Rli+s0ANAiNJUCbEXVCv/3KY0YIfXq5U89AAAA4EMW3LpA1cer9dJ7L7mOElxf+pKUnS398IeukwBAi9BUCqjdx3ersrZS+Tn5/hQ8elR67TVG3wAAABBVRQOL1LdDXy1as8h1lOC68Ubpc5+Tfvtbac8e12kA4LrRVAqoldWN+5T6+rRPqbxcqq+nqQQAAICoSk1J1ZfHf1mvvP+K3tz3pus4wfW1r0kNDdJ//IfrJABw3WgqBVSkKqKOWR3926dUUiJ17iyNG+dPPQAAAOAK/n7U36tNRhtOK11Nnz7SvfdKTzwh1XJbHoD4RFMpoJr2KaUYH/5fVFcnlZVJc+dKqT7tZwIAAACuoH1We3125Gf1zDvP6MCpA67jBNc3vymdOiU99pjrJABwXWgqBdD7x9/Xztqdyu+T70/B11/3Pv0oKvKnHgAAAHANXx7/ZdU11Onn637uOkpwDR8uzZkjLVoknT3rOg0AfGQ0lQJoZZW3T8m3plJJiZSeLs2c6U89AAAA4BoGdBqggoEF+sWbv9C5unOu4wTXI49INTXSr3/tOgkAfGQ0lQIoKvuUpkyR2rXzpx4AAADQDAvyFujQ6UN65p1nXEcJrsmTpbw86Uc/8tZWAEAcoakUQCuqVmhKnyn+7FPauVPasoVb3wAAABBz0/pO09AuQ7XwjYWy1rqOE0zGeKeVdu6UXnjBdRoA+EhoKgVM9bFq7Tq2S/k5+f4ULCnxHmkqAQAAIMaMMZqfN18bD27UqupVruME1513SjffLH3/+xLNNwBxhKZSwKysjsI+pUGDpNxcf+oBAAAAH8F9w+5Tp+xOWrhmoesowZWSIn3jG9Lbb0tLlrhOAwDNRlMpYCJVEd2QfYOGdR3W8mInT0qRCKeUAAAA4Ex2erYeGvOQXnrvJe2s3ek6TnD9zd9IPXp4p5UAIE7QVAqYSFVEU3J82qe0ZIl08SJNJQAAADj1hXFfUGpKqn669qeuowRXZqa0YIG0fLm0fr3rNADQLDSVAuSDfUp+jr516CDddps/9QAAAIDr0LNdT827ZZ6efPtJnTx/0nWc4HroIal9e04rAYgbNJUCJFIVkeTTPqXTp6UXX/ROKaWnt7weAAAA0AILbl2gE+dP6Ncbfu06SnC1ayc9/LB3C9yOHa7TAMA10VQKkEh1RJ2yO2lol6EtL/a730nHj3ufdgAAAACOje85XhNumqBFaxapwTa4jhNc8+dLGRnSj37kOgkAXBNNpQCJVEU0pY8P+5SslX72M2nYMGniRH/CAQAAAC00P2++Kmsr9fL2l11HCa5u3aT775eeflo6cMB1GgC4KppKAVF1rEpVx6qUn5Pf8mJr1kgbNkhf+IJkTMvrAQAAAD74+OCP66Z2N2nRmkWuowTb178uXbggLeL/TgCCjaZSQPi6T+mxx6S2baX77mt5LQAAAMAn6anp+uK4L2rZrmXafHCz6zjBNWCA9IlPeL/XHz7sOg0AXBFNpYCIVHn7lIZ0GdKyQocPS7//vfS3f+s1lgAAAIAA+fzozys7LVs/WfMT11GC7Tvfkc6elb78ZddJAOCKaCoFRKQqovw++S3fp/SrX3lHZR9+2J9gAAAAgI86teqkzwz/jH6z6TeqOV3jOk5wDR0q/e//LT3zjHerMwAEEE2lANhVu0vVx6tbPvpWXy/94hfSlCnSkBaeeAIAAACiZP6t83W+/ryeePMJ11GC7VvfkkaP9j4wZgwOQADRVAoA3/YplZdLu3Z5C7oBAACAgLql8y2alTtLj61/TBfqL7iOE1zp6dKvfy3V1kpf+pLrNADwV2gqBUCkOqIbW92oWzrf0rJCjz3mXUF6113+BAMAAACiZH7efO07uU/Pb3nedZRgGzZM+u53vb2pL7zgOg0A/AWaSgHwSvUrmpIzpWX7lHbtkkpLpc9/XsrI8C8cAAAAEAWh/iEN7DRQC99YKGut6zjB9sgj0pgx3hhcDXuoAAQHTaUAeOuht/TjWT9uWZHHH5dSUqQHH/QnFAAAABBFKSZFXxn/Fa3bt05v7HnDdZxgS0vzxuCOH2cMDkCg0FQKgA5ZHZTTIef6C5w7Jz35pHTHHdJNN/kXDAAAAIii+0fer/aZ7bVwzULXUYJv6FBvDO7ZZ6XnGRkEEAw0lRLB8897t0GwoBsAAABxpE1GG31+9Of1wpYXtPv4btdxgu+b35TGjvV+72cMDkAA0FRKBI89Jg0cKE2b5joJAAAA8JF8afyXZGX1s3U/cx0l+C4dg/viF12nAQCaSnHv7bel11/3lval8P9OAAAAxJecDjn62KCP6Yk3n9CZi2dcxwm+IUOkf/5n6bnnvC8AcCjmXQhjTC9jzApjzFZjzLvGmPmN37/BGLPEGLOj8bFjrLPFpZ//XMrOlu6/33USAAAA4LrMz5uv2nO1+s3G37iOEh++8Q1p3DhvDO7QIddpACQxF0db6iT9o7V2sKRbJX3RGHOLpG9JWmatHSBpWeNzXM2xY9Jvfyt9+tNSR3pwAAAAiE+Tek/S6O6jtWjNIllrXccJvqYxuBMnGIMD4FTMm0rW2v3W2rca//mkpK2Sekq6U9LTjS97WtJdsc4Wd/7rv6QzZ1jQDQAAgLhmjNGCvAXaenirluxc4jpOfLjlFul73/Mu7Xn2WddpACQp4/KTAGNMH0mrJA2V9L61tsMlf1Zrrf2r4zfGmAclPShJvXv3/v/bu+84qaqD/+Ofs8tKU8CCHbErKBGR6KNgb9g1lkewJDYssUA0RlNNHo01/tTEAkEloiiiYoliiRAlWEFRQEAEVEoUCBhpUnbP74+zK7sIyAC7dy/7eSc3M3P37syXfd3AznfOOXevzz77rGbC1jYxQqtW0KwZvPVW1mkkSZKkNbJwyUJa3tGSdlu044UzXsg6Tj4sWQIdOsCECTB6NGy2WdaJJK0jQgjDY4ztv++4zFZ2DiGsDzwJdIsxfr2q3xdj7BljbB9jbN+8efPqC1jbDR4M48Y5SkmSJEnrhPr16nPJDy9h4CcDGTdzXNZx8qFePXjwQZgzJ70vcOqgpBpWL4sXDSGUkAqlR2KMT5Xv/jKEsEWM8d8hhC0AV5xbmXvugY02gtNOyzpJtYoRFi2CefPSTL9581Z8f0X7Fi+G0tK0lZUtvb8m+yqyVfy7Xfl2efsKOX5FP4fv+zlJkqSaV1wM//d/cOmlWSdZN1y414XcMOQG7nr7Lu4+5u6s4+RD69bwhz/ANddAv35w+ulZJ5JUh9T49LcQQiCtmTQrxtit0v5bgf/EGG8KIVwDbBRjvHplz9W+ffs4bNiw6g1cG02dCi1bws9+BrfcknWagi1eDJ9+CuPHL90mTEjrji+vFKoocVZVSQk0agSNG6fbkpL0C1/FVlRU9fHq7AshvVYIVe+vbF8hxy/Pyr62Kl+XJElr3/DhMHQoDBoEBxyQdZp1wznPnMPjox9nSvcpbNjQi9GsEqfBSVrLVnX6WxalUkcmnjpwAAAgAElEQVRgCDASKCvf/UvgbeBxYBvgc+DUGOOslT1XnS2VrrsufRoxfjzssEPWaZartBQ+/7xqcVSxTZqU/t2r0LQp7LgjbLzx0jKoohCqfLuq+0pKsvtzS5KkumXOHGjfPt2OGAGbbpp1ovwb8cUI9uyxJ7cefitX7XdV1nHyY8wY2HNPOPpoePJJP3GUtEZqbam0NtXJUmnx4jRKqW1beCHbBQzLytKgqeUVRxMmpGlrFRo3hp12Wv7WvLn/5kmSpPz68EPYZx/o2BFefDGNataaOaj3QUz6ahITLp9AvaJMVuzIp1tvhauvhr59oXPnrNNIyjFLpXXVE0/AqafCc8/BscfW6EtPngwPPJB+cRo/Hj75BBYsWPr1Bg3SiKPlFUdbbGFxJEmS1l333w/nn58GlP/ud1mnyb+nxz7NSf1O4t5j7uWi9hdlHSc/SktTu/nxx2ka3OabZ51IUk5ZKq2rDjkEJk5MQ4Fq6GOwYcPg9tvh8cfTgtA777z84mjrrdOaQ5IkSXVNjPCTn0CfPvDKK3DooVknyreyWMaRDx/Jvz7/F8MuGMZum+6WdaT8GDs2zWo46ih46ik/2ZW0WiyV1kVjxqSrO9x4Y7q6QzUqLU2DoW6/HYYMgQ02gAsugMsvT7PvJEmSVNW8ebD33jBzJrz/Pmy5ZdaJ8u2LuV+wx3170LxRc9654B0alTTKOlJ+3HYb/Pzn8Mgj0KVL1mkk5dCqlkqOK8mTe++F9daDc8+ttpeYNw/uvht23RVOOikttn377TBlCvzpTxZKkiRJK9K4MfTvD3PnpuVsKl+YRIXbfP3NeejEhxg9YzTdX+yedZx86d4d9t0XLrsMvvgi6zSS1mGWSnkxdy787W9pPaVquKzItGlw7bXQogVcemm6Etvjj6d1k7p3hyZN1vpLSpIkrXNat4YePeD11+G3v806Tf4dueORXL3f1fR8ryf9R/fPOk5+FBfDgw/C/Plw0UVpfqYkVQNLpbzo2xe+/houuWStPu2IEXD22bDttnDLLWnJpqFD4a23Un9Vz4ttSJIkFeTMM9OyATfeCAMHZp0m/64/5Hr22WofLnjuAibNnpR1nPzYZRe4/np45pn0XkKSqoFrKuVBjGmxvRDSBP01XGyvrAxeeCFNaxs8GNZfH847L62XtP32aymzJElSHbZgQZp9NHly+hCvRYusE+XbpNmTaNujLa02acWQc4ZQUlySdaR8KC2FAw5Ia7OOHp0uySxJq8A1ldYlb74JH36YRimtQaE0f34ajt26NRx3HIwfD7femn7ZueMOCyVJkqS1pWHDtL7S4sVw2mmwaFHWifJtuw23o9dxvXh76tv8ZvBvso6THxXT4BYscBqcpGphqZQH99yTFjVazSs3fPEF/OY3sM026d+S9ddPI2AnToSrroJmzdZyXkmSJLHTTnD//WlZgWuvzTpN/p2626l0bdeVm4fezMsTXs46Tn7svDPccAM8+2y6GpwkrUVOf6vtpk9P46UvvBDuuqugbx03Dm6+Of3bsXgxHH88XHkldOy4xjPoJEmStIouuwz+8hcYMABOPDHrNPk2f/F89v7r3syYP4MPLvqAzdffPOtI+VBaCgceCB99BKNGwZZbZp1IUi3n9Ld1xQMPpPHSF19c0LcNHgzt20O/fmmhyHHj4OmnYf/9LZQkSZJq0m23pd/LfvKTNFJcq69RSSP6ndKPOQvncNaAsyiLZVlHyofi4vS+YsGC9GF1jgcWSKpdLJVqs9JSuO8+OPhgaNVqlb/tmWfgqKOgZUv4+OP0ydhOO1VjTkmSJK1Q/frw+OPpg73TToOFC7NOlG+7bbobd3a6k39M/Ae3DL0l6zj5sfPO8Mc/wt//Dn36ZJ1G0jrCUqk2GzgQPvssLdC9ih56CE4+GfbYA157DbbaqhrzSZIkaZVstx307g3Dh6flCLRmzm93Pqftdhq/HvRr3pz8ZtZx8uPyy6FDB7jiinRFOElaQ5ZKtdk996TLfp5wwiod/uc/w49/DAcdBK++ChtvXL3xJEmStOpOOCEVSnffnZYo0OoLIdDz2J60aNqCzk92ZvaC2VlHyofi4vQpdP36cMghaVqDJK0BS6XaasIEePFF6NoVSkpWemiM8Ic/pA8eTjwxjWhdf/0ayilJkqRVduONsO++cP75vp9fU00bNOWxkx9j6pypXPDcBeT5AkQ1avvtYdCgtNTGwQfDJ59knUhSjlkq1VY9ekBRUVpleyXKyqB7d/jd79Lij/37Q4MGNRNRkiRJhSkpSaOU6teHU09N6yZr9e2z9T7ccMgNPDnmSXoO75l1nPxo3TpNbVi4MBVLriAvaTVZKtVGCxbA/fenYUcrWRRpyRI47zy4807o1i19S716NZhTkiRJBWvRAh5+GD78MI0015q5ar+rOGKHI+j2UjdGfjky6zj50aZNKpbmz0/F0mefZZ1IUg5ZKtVG/fvDrFkrXaD7m2/Sp1u9e6epb7ffngY2SZIkqfbr1Al++Uvo1SstcaPVVxSKeOjEh2havyn/+8T/Mm/RvKwj5ccee8Arr8DXX6diafLkrBNJyhlriNronntgl13SX+zLMWcOHHssPP003HUX/OY36RK1kiRJyo/f/x4OPBAuvhhGj846Tb5ttv5mPPyjhxk7cyzdXuyWdZx8adcOXn4Z/vOf9P5j6tSsE0nKEUul2mb4cHj77TRKaTlN0axZcNhh8M9/pk+1Lrus5iNKkiRpzdWrB48+mi6wcuqpMHdu1ony7bDtD+OajtfQ6/1ePDbqsazj5MsPfwgvvQTTp6di6d//zjqRpJywVKpt7r0XGjWCH//4O1+aNg0OOAA++ACefBLOOiuDfJIkSVprttgiFUtjx6bPFL2A2Zr5/UG/Z9+t96Xrc12ZONvFpwvyP/8DAwemNx2HHAJffpl1Ikk5YKlUm8yeDX37wplnQtOmVb40cSJ07JjWzxs4EE44IaOMkiRJWqsOOQSuuw769EkXXtHqKykuoe/JfSkuKub0J05nUemirCPlS4cO8MIL8Pnn6cScMSPrRJJqOUul2uRvf0tXfrv44iq7R41KhdJ//wuDBq1wqSVJkiTl1K9+BYcfDpdeCiNGZJ0m37Ztti29juvFu9Pe5Vev/irrOPlzwAHw97/DpElw6KEwc2bWiSTVYpZKtUVZWVqge7/9oG3bb3e//Xb6ez0EGDIkTXeWJEnSuqW4GB5+GDbeOK2v9PXXWSfKt5Nbn8zF7S/mtjdvY+D4gVnHyZ+DD4Znn4Xx41PbOWtW1okk1VKWSrXFoEHpL+1LLvl216uvpg8HNtoI/vUvaN06w3ySJEmqVptuCo89lgaInH++6yutqT8d8SfabNqGHz/9Y/49x4WnC3bYYely0x99BEccAV99lXUiSbWQpVJtcc89sMkmcMopAAwYAEcfDdtvn0YobbddxvkkSZJU7fbfH/74R+jfP91q9TUsaUi/U/oxb/E8zhxwJqVlpVlHyp8jj4SnnoIPP0z3//vfrBNJqmUslWqDKVPgmWfSR1L169O7d+qW9toLXnstXRVEkiRJdcNVV0GXLvDrX8O11zpiaU20at6KuzrdxaBJg7h56M1Zx8mnY46BJ56A996Do46COXOyTiSpFrFUqg169ky/LVx4IXfeCeeck6a9vfIKbLhh1uEkSZJUk4qK4KGH4MIL4aab0uoIpQ6yWW3n7nkup+9+Or8d/FuGfj406zj5dPzx0K8fvPNOmk4xd27WiSTVEpZKWYsR+vQhHn0Mv3twW7p1g5NPhueeg8aNsw4nSZKkLBQXw733wjXXwH33wZlnwuLFWafKpxAC9x1zHy2btaTLU12YtcBFp1fLj34Ejz4Kb76ZRi/Nm5d1Ikm1gKVS1kKg7K13uGKjPvzhD3DuuWmBxvr1sw4mSZKkLIUAN94IN9+cfj888USYPz/rVPnUtEFTHjv5MabNmcb5z55PdE7h6jn1VOjTJ11F6PjjPSElWSplbckS+MnPm/PnPs248kro1Qvq1cs6lSRJkmqLq69OqyUMHAidOrlW8ur64VY/5KZDb2LA2AF0fa4r3yz5JutI+dS5M/TuDYMHp6bzG3+OUl1mqZSxoqI0vPn66+HWW9MnUpIkSVJlF1yQRiu99RYcfDDMmJF1onzqvm93rulwDb3e70WHBzowafakrCPl01lnwQMPwD/+ASedBAsXZp1IUkZCnod+tm/fPg4bNizrGGssRsskSZIkfb8XX0xL22yzDbz8crpV4Z4d9yxnDzibolBEn5P6cMzOx2QdKZ969UqN5zHHwFNPwXrrZZ1I0loSQhgeY2z/fcc5UqkWsFCSJEnSqujUKZVJX3wBHTvCxx9nnSifjt/leIZ3HU7LZi059tFj+fWgX1Na5iX2Cnb++WlF+eefh2OPhQkTsk4kqYZZKkmSJEk50rEj/POfacZRx47w/vtZJ8qnHTbagTfOfYPz9jyPG4bcwJEPH8n0edOzjpU/F12UFv164w1o3TotAubCX1KdYakkSZIk5UzbtjBkCDRsCAcdlO6rcA1LGtLr+F7cf/z9DJ08lHY92vHG5DeyjpU/F1yQhs116QK33QY77QT33ZeuSiRpnWapJEmSJOXQzjunK7tvuSUceSS88ELWifLr3D3P5c3z3qR+vfoc2PtA7nzrTvK89mwmttwSHnwQhg2DVq3g4othzz3hlVeyTiapGlkqSZIkSTnVogW8/np6D3/CCdCvX9aJ8qvt5m0Z3nU4R+90NN1e6sbpT57OnIVzso6VP+3apfmZTzwB8+bBEUfAccfBuHFZJ5NUDSyVJEmSpBxr3hwGD4b99oPOnaFHj6wT5VezBs0Y8L8DuOnQm3jioyf44V9/yOjpo7OOlT8hwMknw5gxcMst8NprsPvu0K0bzJqVdTpJa5GlkiRJkpRzTZrAiy/C0UendZNvuinrRPlVFIr4Rcdf8OrZr/LVN1+xd6+96Tuyb9ax8ql+ffj5z+GTT+C88+DPf4Ydd4S77oLFi7NOJ2ktsFSSJEmS1gENG8KAAWmt5GuvhV/8AlwWaPUdtO1BvHfhe7Tboh1nPHUGl75wKQuXLMw6Vj5tumlauHvECNhrL7jiCmjTBp5/3pNUyjlLJUmSJGkdUVICffrAJZekWUcXXQSlpVmnyq8tN9iSQWcP4sp9r+Tud+/mgN4H8Pl/P886Vn61aQMvvwzPPZfKpGOPTavMjxqVdTJJq8lSSZIkSVqHFBXBX/4Cv/oV9OyZRi4tWpR1qvwqKS7htiNu48nTnmTMjDG069GOlz55KetY+RVCKpNGjoQ77khXi9tjj3S1uBkzsk4nqUCWSpIkSdI6JgS4/nq47TZ4/PF0Zbj587NOlW8/avUjhnUdxpYbbMlRjxzF7//5e8piWdax8mu99dI0uPHj4ac/hb/+Na23dOutsNBphlJeWCpJkiRJ66grr4RevdKMoyOOgK++yjpRvu288c68df5bnLXHWVz32nUc/cjRzJw/M+tY+bbxxmnh7lGjYP/94eqroXVreOop11uScsBSSZIkSVqHnXce9OsH77wDBx8MU6ZknSjfGpU0ovcJvelxbA8GfzqYdj3a8faUt7OOlX+77gp//zu89FJadf7kk9MJ+8YblktSLWapJEmSJK3jTjklvV//+GPYYQc45xz48MOsU+VXCIGue3Vl6LlDKQpF7Hv/vhzU+yB6Du/JrAWzso6Xb0ccka4Sd++9MHo0dOgALVvC5ZfDoEGweHHWCSVVEmKOW9/27dvHYcOGZR1DkiRJyoWJE9PayA88APPmwWGHwc9+li7AVeTHzatl1oJZ3P3O3fQd1ZexM8dSUlRCpx070aVNF47b+Tgar9c464j59fXXaRrc00+nEUzffAMbbpgW+j7ppFRANfbnK1WHEMLwGGP77z3OUkmSJEmqW2bPTleGu+sumDYNWrVK5dIZZ6SZRypcjJERX4yg78i+PDrqUabOmUrjksacuOuJdGnThcO3P5yS4pKsY+bXvHlpcbCnn4bnnksncYMGqVg66aRUNG2ySdYppXWGpZIkSZKklVq0CPr3hz/9Cd5/H5o3h0suSdumm2adLr/KYhlDPhtC35F96f9Rf2Z/M5uNG27MabudxhltzmDfFvtSFBwattoWL4YhQ1LB9PTTMHlyGmq3//5w4olp23bbrFNKuWapJEmSJGmVxAivvQa3354GgdSvD2eeCd27w267ZZ0u3xaVLuKlT17ikZGP8Oy4Z1mwZAEtm7ak8+6d6dKmC202a5N1xHyLMTWiAwakgmnUqLS/bdulBdMPfgAhZJtTyhlLJUmSJEkFGzcO7rwTeveGBQugU6dULh1+uO/L19SchXN4Ztwz9B3Zl5cnvExpLGX3TXeny+5d6NymM9s22zbriPn3ySdLRzBVXDluu+2WFkwdOkBxcdYppVrPUkmSJEnSaps5E3r0gL/8Bb74AnbfPa271KVLGsmkNTNj3gz6f9SfviP7MnTyUAA6tOhAlzZdOLX1qTRv3DzjhOuAL79MQ+8GDIB//CPN99xkEzjuODjqqDSCaccdLZmk5bBUkiRJkrTGFi6Exx5LU+M+/BA22wx++lO46KK0BpPW3Kdffcpjox7jkZGPMGr6KIpDMUfscASntD6Ftpu3ZZeNd/Eqcmtqzhx48cVUMD3/fLqyHKSGtHXr1JpW3lq0cGie6jRLJUmSJElrTYzw6qupXBo4MF146+yzoVu3dPU4rR0jvxxJ35F96TuqL5//9/Nv97do0oJWzVux68a7susmS7fN19+cYPlRmEWL4IMPYPTotAZTxTZ16tJjmjT5btG0++42qaozLJUkSZIkVYuPPoI77oCHHkojmTbcEHbaqeq2887ptmnTrNPmU1ksY+zMsd9uY2aO+fb+3EVzvz2uaf2mVUqmim2HDXegpLgkwz9BDs2eXbVkGjUKRo5M+ytsttl3i6bddoMNNsgut1QNLJUkSZIkVavp06FfPxgzBj7+GMaPT1d3r/wWo3nz5RdOO+4I66+fXfa8ijEybc60KiVTxTZ1ztKRNvWK6rHjRjumkmmZ0U1NG9j0rbIY06JiFQVTRdk0ejTMn7/0uG23Tdsmmyzdmjdf/uOGDbP600irLLelUgihE3AnUAz0ijHetKJjLZUkSZKk2uWbb2DChFQwVWwVhdO0aVWP3WKL5Y9u2mEH33evjq8Xfs24meOWFk3/GcuYGWMYP2s8S8qWfHtc80bN2aTRJmzUcCM2argRGzbckI0alN823IgNG2y4dH/5Mc0aNKNeUb0M/3S1TFkZfPpp1RFNU6emFe5nzID//Kdqu1pZo0YrL52WfdykSVr7yWmOqkG5LJVCCMXAx8DhwBTgXaBzjPGj5R1vqSRJkiTlx7x56YrvlQunitJp+vSqx261FTRrBo0bp61Ro6q3q7OvYcO6+b58celiJn016duy6ZNZnzBrwSxmfzM73S5It3MWzVnp8zSp3+Q7hVPF4w3W24D69eqzXvF61C9OtxVbxf5lv7ay/UWhqIZ+OtWktBS++mppyTRz5nfvL/t4zkp+/iGkE7hia9SosPvL+1r9+lCvXtpKSgq7Xxf/j1TH5LVU2he4LsZ4ZPnjawFijDcu73hLJUmSJGnd8PXXVYumiRPTvnnz0iyjyrcV97/5pvDXadQovScuKkpXkq+8re6+oqKl77FDqHp/bexbke97X1/o95bFMhaXLmJR6SIWlS5mUenC8ttF6X7ZYhYtWcSisopjlm4xlq08TIECgaJQRAhF6edCEaE8eCAQQkiPK90PhKVfh/IFzJd3bMXjiudb9pUrP1zVry//h/3dvcs5rmJXjFBWRigrg9IyKCtNI6LKYvraSreyFexfbqyVJC7A952sYTmvssJ9y+4PKwkYlnt35UKVm+r01z8248hTDqj+F6pmq1oq1bbxi1sBkys9ngLsU/mAEEJXoCvANttsU3PJJEmSJFWbJk1gr73StqpKS1O5tKLSadn7Fbelpd/dyspWb9+iRWkfLH0fX3F/bexbke8bG7B631sENCjfvqsYaFi+LfOM6T+x4rZ8TyxbjcdUep6y8k4kVvyX7/xv+fdWSRKhbJWOrfpnWPbuio787t5VHKixCod995C1NAgkfudO+d2VnSir8PrLe95CrfBba88AmEJ89dVnWUeoUbWtVFpeb1jlTIox9gR6QhqpVBOhJEmSJNU+xcXpolteeCtrgRoZAiLlwq5ZB6hRtW2i6hSgRaXHWwPTVnCsJEmSJEmSMlLbSqV3gZ1CCNuFENYDTgeezTiTJEmSJEmSllGrpr/FGJeEEC4FXiJN2X0gxjg641iSJEmSJElaRq0qlQBijC8AL2SdQ5IkSZIkSStW26a/SZIkSZIkKQcslSRJkiRJklQwSyVJkiRJkiQVzFJJkiRJkiRJBbNUkiRJkiRJUsEslSRJkiRJklQwSyVJkiRJkiQVzFJJkiRJkiRJBbNUkiRJkiRJUsEslSRJkiRJklQwSyVJkiRJkiQVzFJJkiRJkiRJBbNUkiRJkiRJUsEslSRJkiRJklQwSyVJkiRJkiQVzFJJkiRJkiRJBbNUkiRJkiRJUsEslSRJkiRJklQwSyVJkiRJkiQVLMQYs86w2kIIM4DPss6xlmwCzMw6hDLlOSDwPFDieSDPAYHngTwHlHgeKItzoGWMsfn3HZTrUmldEkIYFmNsn3UOZcdzQOB5oMTzQJ4DAs8DeQ4o8TxQbT4HnP4mSZIkSZKkglkqSZIkSZIkqWCWSrVHz6wDKHOeAwLPAyWeB/IcEHgeyHNAieeBau054JpKkiRJkiRJKpgjlSRJkiRJklQwSyVJkiRJkiQVzFIpYyGETiGEcSGET0II12SdRzUvhPBACGF6CGFU1lmUnRBCixDC4BDCmBDC6BDCFVlnUs0KITQIIbwTQvig/Bz4fdaZlJ0QQnEI4f0Qwt+zzqKaF0L4NIQwMoQwIoQwLOs8ykYIoVkI4YkQwtjy3w/2zTqTalYIYZfyvwcqtq9DCN2yzqWaFULoXv674agQwqMhhAZZZ6rMNZUyFEIoBj4GDgemAO8CnWOMH2UaTDUqhHAAMBd4KMa4e9Z5lI0QwhbAFjHG90IIGwDDgRP9+6DuCCEEoHGMcW4IoQT4F3BFjPGtjKMpAyGEnwHtgSYxxmOzzqOaFUL4FGgfY5yZdRZlJ4TwN2BIjLFXCGE9oFGM8auscykb5e8dpwL7xBg/yzqPakYIYSvS74StY4wLQgiPAy/EGHtnm2wpRypla2/gkxjjxBjjIuAx4ISMM6mGxRhfB2ZlnUPZijH+O8b4Xvn9OcAYYKtsU6kmxWRu+cOS8s1PfuqgEMLWwDFAr6yzSMpGCKEJcABwP0CMcZGFUp13KDDBQqlOqgc0DCHUAxoB0zLOU4WlUra2AiZXejwF30RKdV4IYVtgT+DtbJOoppVPeRoBTAdeiTF6DtRNdwBXA2VZB1FmIvByCGF4CKFr1mGUie2BGcCD5VNhe4UQGmcdSpk6HXg06xCqWTHGqcBtwOfAv4H/xhhfzjZVVZZK2QrL2een0lIdFkJYH3gS6BZj/DrrPKpZMcbSGGNbYGtg7xCCU2LrmBDCscD0GOPwrLMoUx1ijO2Ao4Cflk+VV91SD2gH3Btj3BOYB7j+ah1VPv3xeKB/1llUs0IIG5JmM20HbAk0DiGcmW2qqiyVsjUFaFHp8dbUsqFskmpO+To6TwKPxBifyjqPslM+xeGfQKeMo6jmdQCOL19T5zHgkBDCw9lGUk2LMU4rv50ODCAtmaC6ZQowpdKI1SdIJZPqpqOA92KMX2YdRDXuMGBSjHFGjHEx8BSwX8aZqrBUyta7wE4hhO3K2+fTgWczziQpA+WLNN8PjIkx3p51HtW8EELzEEKz8vsNSb9EjM02lWpajPHaGOPWMcZtSb8XDIox1qpPJFW9QgiNyy/YQPl0pyMArxBbx8QYvwAmhxB2Kd91KODFO+quzjj1ra76HPifEEKj8vcLh5LWXq016mUdoC6LMS4JIVwKvAQUAw/EGEdnHEs1LITwKHAQsEkIYQrwuxjj/dmmUgY6AGcBI8vX1AH4ZYzxhQwzqWZtAfyt/OouRcDjMUYvJy/VPZsBA9J7B+oBfWOML2YbSRm5DHik/MPnicA5GedRBkIIjUhXC78w6yyqeTHGt0MITwDvAUuA94Ge2aaqKsToEj6SJEmSJEkqjNPfJEmSJEmSVDBLJUmSJEmSJBXMUkmSJEmSJEkFs1SSJEmSJElSwSyVJEmSJEmSVDBLJUmSVCeEEDYOIYwo374IIUyt9PiNanrNPUMIvcrvXxdCuKo6XmcFr90mhNC7pl5PkiTVPfWyDiBJklQTYoz/AdpCKniAuTHG26r5ZX8JXF+dLxBCqBdjXLLs/hjjyBDC1iGEbWKMn1dnBkmSVDc5UkmSJNV5IYS55bcHhRBeCyE8HkL4OIRwUwjhjBDCOyGEkSGEHcqPax5CeDKE8G751mE5z7kB8IMY4weVdrcOIfwzhDAxhHB5pWN/FkIYVb51K9+3bQhhVKVjriovwyh/jj+GEF4DrgghnFr+vR+EEF6v9HrPAaevvZ+UJEnSUo5UkiRJqmoPoBUwC5gI9Iox7h1CuAK4DOgG3An8vxjjv0II2wAvlX9PZe2BUcvs2xU4GNgAGBdCuBf4AXAOsA8QgLfLy6LZ35OzWYzxQIAQwkjgyBjj1BBCs0rHDAOuAW5Z5T+9JEnSKrJUkiRJqurdGOO/AUIIE4CXy/ePJBVCAIeRRh1VfE+TEMIGMcY5lZ5nC2DGMs/9fIxxIbAwhDAd2AzoCAyIMc4rf82ngP2BZ78nZ79K94cCvUMIjwNPVdo/Hdjye55HkiRptVgqSZIkVbWw0v2ySo/LWPq7UxGwb4xxwUqeZwHQYCXPXVr+fIHlW0LVpQqWfa55FXdijBeFEBLKJyoAAAEuSURBVPYBjgFGhBDalq8h1aA8hyRJ0lrnmkqSJEmFexm4tOJBCKHtco4ZA+y4Cs/1OnBiCKFRCKExcBIwBPgS2LT8qnX1gWNX9AQhhB1ijG/HGH8LzARalH9pZ747BU+SJGmtcKSSJElS4S4H7g4hfEj6fep14KLKB8QYx4YQmi5nWhzLHPdeCKE38E75rl4xxvcBQgh/AN4GJgFjV5Ln1hDCTqRRT68CFYuDHww8X+gfTpIkaVWEGGPWGSRJktZJIYTuwJwYY68MXrs+8BrQMca4pKZfX5Ikrfuc/iZJklR97qXqOko1aRvgGgslSZJUXRypJEmSJEmSpII5UkmSJEmSJEkFs1SSJEmSJElSwSyVJEmSJEmSVDBLJUmSJEmSJBXMUkmSJEmSJEkF+//9kfg3YOp0pgAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 1440x720 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#%matplotlib inline  ## This line controls showing the plot within the Notebook\n",
-    "hydrograph_fig = plt.figure(figsize=(20, 10) )\n",
-    "plt.plot(hydrograph_time, discharge_at_outlet, 'r-', label = 'outlet')\n",
-    "plt.plot(hydrograph_time, discharge_midstream, 'g-', label = 'midstream')\n",
-    "plt.plot(hydrograph_time, discharge_upstream, 'b-', label = 'upstream')\n",
+    "hydrograph_fig = plt.figure(figsize=(20, 10))\n",
+    "\n",
+    "# Plot hydrograph series.\n",
+    "plt.plot(hydrograph_time, discharge_at_outlet, 'r-', label='outlet')\n",
+    "plt.plot(hydrograph_time, discharge_midstream, 'g-', label='midstream')\n",
+    "plt.plot(hydrograph_time, discharge_upstream, 'b-', label='upstream')\n",
+    "\n",
+    "# Configure plot elements.\n",
     "plt.ylabel('Discharge (cms)')\n",
     "plt.xlabel('Time (hours)')\n",
-    "plt.legend(loc = 'upper left')\n",
-    "title_text = 'Model=' + str(basin_flag) + '+'+ str(storm_flag) + '+ ' + routing_method \n",
+    "plt.legend(loc='upper left')\n",
+    "title_text = 'Model=' + str(basin_flag) + ' + ' + str(storm_flag) + ' + ' + routing_method\n",
     "plt.title(title_text)\n",
-    "plt.savefig(basin_flag + '_' + storm_flag + '_' + routing_method + '_hydrograph.png',format ='png',dpi=1000)"
+    "\n",
+    "plt.savefig(basin_flag + '_' + storm_flag + '_' + routing_method + '_hydrograph.png', format='png', dpi=1000)"
    ]
   },
   {
@@ -895,32 +749,21 @@
    "source": [
     "### 6.2. Show map for one model result at the time step of interest to you \n",
     "\n",
-    "List the available image files printed in each model run and animation increment that you would like to view. Note that you will need to change the last line of the code block below to visualize the model run you want to see."
+    "The code you ran above produced image files of model output. \n",
+    "\n",
+    "List the available image files printed in each model run. The files have a naming structure that includes the model time. Note that you will need to change the last line of the code block below get the file names for a given model.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The model your have just run will have individual snapshots of the aninimation with this file naming structure --\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_0.0hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_1.33333333333hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_2.66666666667hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_4.0hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_5.33333333333hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_6.66666666667hr_map.png\r\n",
-      "Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_hydrograph.png\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print('The model your have just run will have individual snapshots of the aninimation with this file naming structure --')\n",
-    "#change this shell script below list all file names for a png based on your model (e.g. *png, Spring*png, or Square*png)\n",
+    "print('Image file names:\\n')\n",
+    "\n",
+    "# Change the shell script below to list all file names for a png based on your model (e.g., *png, Spring*png, or Square*png)\n",
     "!ls Spring*png"
    ]
   },
@@ -933,46 +776,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Figure size 7200x7200 with 0 Axes>"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD8CAYAAACRkhiPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3X2QJOV9H/Dv0z2vu7fLno7jQBx34U1WSMAi8ZFIMdhCBsslWSqrKGGjiyJIueyqXBxipSxMuYLyUhWoRKKKQuXEikCyJROJlGXZsvyPwDiHLelELARWpSQMCA4O7g3u9m53dqen+8kfc89sT093T789/fr9UFPcTs/09M7O/H7P+yOklCAiomYyir4AIiIqDpMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRgzEJEBE1GJMAEVGDMQkQETVYq+gLmIPTmYmIZomsTsSaABFRgzEJEBE1GJMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRgzEJEBE1GJMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRg5V9FVGiQEKMF1KU0n+xWXVcCXtc0DGiumNNgCpJCIF77rln7uOklAzwRCGYBKiS5gV2b+n+c5/73EzNwPt4dQu6333M73FB5wo6B1EZMAlQ5SQJpHfccUfocVVjkFLCsqzJ67jvj8P9nBtvvDHxeYh0YxKgSsmj/f6mm27K9HyPP/44awFUWuwYpsrxa4rxSwwf//jH8alPfWrymC996Uu5XJ+X+9rYCU1lw5oAVYq7WUV1DKug6k4OUkp8+tOfnnrubbfdFvv1opTeWcKnKmNNgGpLSjl3GGmU5/udw3vueZ3O7ucRlYko+Yey1BdHRFSQzKqfbA4ioloKqp1xuO401gSIqLZq3BHPmgARkZ95JfzV1VXWAlxYE6gofoipauLGGiEEulf/auDxzWc/i9OnTwMAlpeXp57nHjFW0zWjMgsAHB1ERKUl2v3Q4+7gT8mwOYiIyksYwbcAfkN23T9/8IMfhGma2i65algTIKLyMpIFa9XM4/0/AHzta19Lf101wiRAROXFvi/tmASIIhhY45Jkv82glKuENQGKjkmAKIQK/u6fmQhyFNL2T9lgEiDy4Q3+fseYDHLAmoB2TAJEHmEJIOhxTAiasE9AOyYBonOiBv+g5zIRaGAwROnGd5gaKU3Aj3NOJoaUOJ5fOyYBIiovNgdpxyRAjZJVDUBKxqdcsGNYOyYBqqy47fBZNgG5E0BYQmATUUocIqod32FNPvaxj/luXuG3mUXQY7hSaLC4AV1HH4BaiaCIP5OO36eUDDP4RplgEtDk85///GRDdEUtXete4MrvPgAzzyX94r7dw5EDJ8HfKGkAH1hycvP+HHSLc95SEiL4RplgEtAs7Zrl82oNTaMzYMV9W7ttA2sbdqLXmvc7JA3ocV7nc4demjqe1WtmijUB7dgnUDHuzTKqLCjAuNvLowQhHePz3TnbkRJCAEbA+73Ub8XuJFaPzyvIumc4J21GK6wfg30C2jEJaBanFvDQQw+len6Z6Qx4WQcqd0A3hYCUgO0EJ4O4+bio/F3JyXAs8WvHJKCRtynI3e7vXuc8yn1NkTZQKd6AlaQUrAgxTgaKIyUcBzAE8INXV3H1JedtXcPQRssUaJv5l2DVR8WREhuWjcVutl/vQmoFTALaMQlo5BfA09xXVVnVAhwpA5tlgl5TR8AyhJjEJncCAIB+Z3xgdWCh2zLRbeeXDNRbYwqBxW4LtiNhGtn//rnWCtgcpB3fYaqMqAmgDJb7bUiMS+RFMQ0Re8RTVHn1ZwjDCLxRNvhOUu24A1+Ro1x6bRO9tolT6xY2LaeQa1jbHGk7dx7vq3vOjPdG2WASIK2iBIqsS6tB8aGoES4rC20M7eRJIM37s9A1YTvVbVoUhgi8UTaYBKhSRnZ4QAsKmEWPe1/qtfDyyfVEz01T6DWE0NIvoOh+T1kT0I8dw1QpLTP8y1/q2FDdAnlhDLb9a8d3mCopyXINRdtz/gJOrVuFvHbWb5e330UbEXKjTLAmQIVLUno3hIDjSBjG9Pj9sowgCppFvLLQxnDkoNOaLX/pWp56+74DAIA3v/vg5N9+3vzug5HPmdfbzJqAfkwCVAm+AbIc8d6XulYpAYnp5DSyJYRwpiaU5ZEA3P8Pe+y8x+WJSUA/JgEqhbCJTUElfEOIqWOGENomSKkg7W4G8QZ6SEwSk21LtFvGeMHLc3eeODPE+UsdLHS3ZsFa9jgZZJEA/IJ4nGA+L0EUkhhKnOjrgkmASsPbvKOENvG4Ai8AbSNh1CX4Xcok0LuOGa1oCc12JFYHQ+zY1ol1PSNbTjrJvaV9HYwr/vH4dS5+O9784+AmpcxfN2FN4ODBg7jhhhtCZ96nXeG3LkTJ34RSX1yRqjJEzttpmHTFzSBBtYTB0J4s4aBbnNpH1tflLqHnteWlX60gyhyMuLFGCIGdt3858Pjxh2+de86gQF+Dtbky+0uzwY20CBqXPy9IDUfTk6qSBrV+x8xtBFFQAvB7+X7HxGA4u5TEqbX4s4q3/8J9U8FYiHFtKq64k8nmdTBnKclksXkFJNYApjEJUGH8gnSnZcByza6d9101hIA18g+eRY8UCnp5v0XlVhbbOHF2M94LnDg8c5dfc9o8SZrQ8koEOiaLMQFMYxKgzEUdNx4UpNWoGbWhyzztloHjq/4B1JGydHMKDCEwGNozJfCLt/cjn2P7vgNAb5vvsSyWiYjSvJNHR7FhGIG3JDjjeBaTgEZJN5oPuq+OrJA1dWxHQsrwxyhBHauGEJPROVnIKp9k0S/w5sF7fe9P87Hpt8UkAURJBNv3HdC7JlOCyWJqPw4hBK688srxaVx9ANy/expHB2n09a9/He973/smP7vbItW/591XNXFnjw5HTuAGLOr+KBu0GIbYag8/N5RTnLtfiOwmkmWZl1UzzJmNEZZ68b6Ku254b3YXEsIb4MM27tEhaYnf+/2p+54daTAJaLJz506cOHFi8nPSD5w3Iayurqa+trLJalTLVHu4GI/E6bYMGGpd/ZJWrJZ6LTiOxNB2cOTNDVx2wWLo4+eN2c+y5uOV90qsXC1UPzYHabJ3795JtXNxMfxLHcfy8jKWl5czO1/RFrstbW32/Y45lRjcI4/KVgg0DIFe28RlFyxidRC8vlDWnbFSbjUBFbaZfAiuIqofawKaPPXUU5N/r62tJT5PE6qs3pm/OpjGeEnlY6ubMITA+UvxJmflSUBgfdOemlm8fd8B7P6590fqjI36NpYx6Htx2Qj9mAQ0UqWVO+64A0C9N5oP6gsImgXsJgQwtCTaLf3DOi9Y7uLFY2tzk0BeE6/87Lnhzpn74ozEiXLteY3zT4slfv2YBDRqykbzYZ3Bqj1+3nfZb+y8egs2RzZ67exm2V46p80dSJcAkiQQ99IPUQJ+WHL1e+0qlPr9sE9APyYBSizqSCA1kzXuRKagQJpFKf2HR87gJ966pOX8cZ6rgv9/vP838XOX7oz1OlGvs6oJAGBNIA9MApSLJDNZFcuW6LW3fs5iyKc7AawOLCz12pNVQrOIO37n8TbBRC31+1FDYv2CZJn2VUgrzeeGomESoETS7CYVN9D2WsbMIm1ZBLmzGyNs67Ww3N/KMFnFTndC2b7vALB8AX73934Lv3ztnmxeAMGlZO97M7BkZWsDNcllpcYkQLGl3U7Q3fEdRcs0sGFlvyroYrc1MwonSyoBqNJ+lJnPcc9fd6wJ6MckQLH12yIwEahNUsLEbecVAr7bMaYlBNDz6ZDOysykrgL6+qtaA1BMs9rXXwVMApSpKEs8jJz5icJLVyexECJwz984/IZczrT3i3h7DxA7hvPAJECZc3dMqmGe7u+ySgAbVvShn0F9ABIy1TIJqpZhOxKOM94SMq6oG7u0TWOyxWQWipzLkBc2B+nH6XiUOUOM5waopaCDAlWv7b/BShxZrZNjGgJJVmD2Nvl49yEGpjd62b7YRhbGm9VncqpS47IR+rEmQImE9QsArn13553nXGfvpuVAQobWDM4MRljqT39kgzqZ/Wog88RZw+gffOLPccXlb5lp8vErnbtLs6YhEq0a6tVqSFs5awL6MQlQKfjNGPZa6rdw+OQAO5c7k2Qxb9ZsnCYTlZDm7QO8fd8BYOl8/OC+T84cC2qecl9HP+Xs5zrNA5iniF/TNM2pGfuOk+2orrJhcxBVyiU7+ji7MZr8PK/w7tc8M0+/Y+K5189O3bd93wFcsP/3Jz+f/OY9/q8XUPtxB7OWKTCykw0VGu+T0IwEAIyTfNBNh8985jOwbRuO40xu4+uob6gUJV+jptQXV6QytImmnS/gxxo5kTpnNywbx1eHeOv2XqTRNo6UgIzevHB2Y4QNy8GVN/4mgNmRPmGl8Si1D8t2MBw5WOzGq4zHqtmUbHho3FgjhMBP/ee/CDz+1O+8u1JrbGUssz9ufdMbVVLU0Tm9tolLdvQjfxOMGJ2J2/cdwH/7Py8EJgB1vjTapoHFbiv2fsBR1woqWwJIKu+awNbrpt/PuCrYJ0CJ6KgFJGEYYm4bvqICaNBYffdKngDwyZvD1/XxG+Iad9jmyJb43kun8FOXbo/+JJe6BPsgRXQMm6ZZ+34At3qnuIJxo/n41jfjDxl1pIy9JENQK0KcBd3iTnjz020beMeeldTnqSs1xNjvpottpxu2XDVMAhqp7SW9G8m7hzXOu6+M4tQC8vgV+h0TG1b0JGCe23w+aeesIs7NAJ533zyGq4ZC04poDrr77rtx6623ajt/2bA5SKMsdgfzbjRfBqoJIkoycA/VlJA4MxjhvIXxhKlvPX8S/2jPdnTbBt5cG2L7YgcL3a0JZFEXjDMSvkdqrL1qBnrj0IOxhl8aQmDgs7Bd3P4CW0oYELGXk6h7UxBQzACI++67r1G1ASYBjbw1gCZTk8eWei28eGy85/I7L98xOb7YbU3a9vud+DOJ07y9O3/6Zvzo/g8kGn7pl6jixi3T9YQmLAURRxF9Art27YJpmti1a9fkviNHjuR+HXlhEii5uiUPwxDY/Zb+zCggtYDbpuWg2zbQ75iRAuIrbwywrdvCpT/7bxNt0LL/D/4GP7r/A5Ofs9xYJip3oKvq8E9diqgJ1Dng+2GfgCZPPPHEpHPXu4F8nPvqKOz36rYNnBmMJ4ONQkZoDIY2Tq1ZWOiYWFls483vPog//dt4X97bvvB/8WcPPOS6rvH/T69bsc7jJ27urlmuz0xRQ0S9rrnmmlxfL0+cLFZRZUkQcTqJz5yb6Rtn3ZyjpzfRbY03lTmzMcIHPvWX+H//9X2Bj59Zwz/AB/7Ht/Env/ZPI19HGL8hp2G1Cb/9lh0psTF0Im1wU9VaQJLJYjc+8NeBxx//jXdpqSl75wUIIcrYR8DJYlQOcQJSt2XESgAjW+K8hRZWFtu4cKWHKy/cFpoAgPEQz5++N3iWqeNIXPwvH5lJAN5Y4l6aYh7HZ1RPWI72K8UaQkTa06CqCSAp0xCBtzBhNWl17LnnnvM97l4ywnGcMiaATLFPgLRTJd+4G7c4MnxV0TD/7L/8Bf7qt9+Nl0+sQwL49S8/DSmBtbUh1p/5KwC/Evr8OBWtrHa/4oKZs5JuwBM2KIMDNqYxCZBWfk0fUbUSPu/Ju94NAPjy04dx6zsuAQD8+b96FwD/5iK/ppteO1rHNBCy4U3MDuawJr6m1QCUJM2eDO7xMAmQVmk68NL2e6gEMP91Zu8zDQHH8d+rwM/IljNr/AuRLgkqTU0AQPo1mmg+JgHSwlsKTrKPr2U7aJkidiCIUwIPe2yc4B20xphhiEjXw4KrvyT5c3FxMfXrmqaJj370o5OfH3744dTnLCsmAdJiZnetBCW6TsuIvDicW5x9h7MsaFq2k2o9IRZ6ZyWpRZ09e3ZSg3vppZcATDcRzavdmaZZ+85gNyYB0s4aOWglDI79jhm46qfbyB4/RiJ82Ye4E8qiluINISDm7HIWxm+SWpObgZSkzUFBncF+x7xs225UIuAQUUolyjyBlmmkKuVGGSHSMseLwoUFDbVGUNbUS6ZdlI41gVlFTRZrSgIAmAQohagTxXQGN91t6XGvPWlsYp+AvyKWkvZOFqv7pjL1/u2ocE//+FSq5/tNxHKLGgz++7deTLS2UFxJS6je34NNQWOmEIG3vLz3ve/N7bWKwCQQ06lTp6a2nTPNZJOZGiPldzWrav+j334lk/NQvpLOGM7SN77xjdxeqwhMAjGYpomVlZVGTSlP6x175++aFaUpxEnZXvI3f/jlVM/PS532B86Ce3c+700Xx3Fw1113wTRN7N27V9vrlAVHB8XAgK9Hmlm5dcLgP6uI/QQMw4DjOLj33nunfq4rJoEEvB1Fdf6AkF5qWCgTgL8i1lPy2++7ztgclMD+/funmoTCrKyscKP5Av34+DpsR+JXPvFrsXcr85PVKJ6XT6wDABY6bP4JYwgReNNFSjnp71MFvjr3/bEmkMB3vvOdyI89efIkWq3x2+ydtag2jwm7j9K5aKUH0xB456XL6MZctsJPFrFHSmDP+QvpT9QARTQDNq1mz5pAAkHrkHsJIVKXIMpcGyhbJ+ZgaONbz5+ENXImHcnd9vgjfl63PXlM0dSftEzvXVkVNVlMjf5rgmb8lhmLEpiHwyFL8xr5jRbasGy88/IdaLeMmRJk2zBgGAIvHl/DyyfX87rMQEwA0RQxWcw0zanaQJ2bggAmgURUm2FYaaHb7WbSrv/II4+ken4eigho3iB/et3C9sVO4OP/1/deAwBcdfEy9uwYN8XYjoQjZerhp1GpmhMTQHRlmCdQ98Ic+wQSiNJm6P7gqESg2vvdx/3uu/3222fuKzsV2OLsORwm7oYs5y20Q49/4SPXzty3PrTRMgT6HROOIzFyZOzlrqNi4E8mz5nBim3bk8Jd3YeHAqwJxJK0WuhdwdBvhUP3fQ899JDv45ok6nf/tVMbkR736b98fua+pV5rspewYQi0TAHbkdiw7EzX8mECSK6IyWIAIo/+qwMmgRhs28bRo0enmoKa0nkURVa1ACUsEA+GNlYHFi5a6UU613/6d/fj9Lo1c//O5S5+eOQMgHETk2kI9NrmJAmlbSpiAkinZQTfdGna97v+v2HGdu3aNVVKaEJJIStx46nE7BNsR2IwtHH09CaW++FNQG5/+IXfwf1Pvuh/MCROpxmiyASQXt41AdX806TvN5MA5cYvqIdRAdiyHQyG9mTjmH7HxN6Y4+yfO7mGT978Nt9jP3HREn7wymro822f1UwdKQNXOWUCyIZpBN9yu4aajw5ixzDlxrYlYEYvXVsjB0IIrG3YWFmcLvXHLQj+xvWXhx7/ezvDk4p7NIq707qItW2apAxrRtW9b45JgLTxjvBpt4zAJqHjq5vYsa1zrqq/9XgAMwkgrq8++yp+6eqLQx+z2I3+VZgkAE+AijuiieYzc34/9+7di0svvXTmvjpjEkigCcPGsuAXENV9Uo6bUyzbQadlYOdyN9PXVgH5lz77HXz1V/9JpucOwgSQvbxrAi++GNBvVGNMAgk4jjM1aoAJIZ6//ruTWB1auPntu9BrZ9/e6i6R55UASI882/6bikkgJvfoAYrHdiQMIfCuK3ZofZ2khccTZzZx/lKXzTolUoY+gbpjEoiJwT85w9XenyU1lj9twOi2TKwOLGzrtbBpOZPZqhLQNpOYwhVRE2hacy+TAOVGRwKQMrvS4lJ//HWwHTnTTKVqB6ovI2ztGg4PzU4Ry0YAzdo4isUbykTYbGGdI+zCYsT2fQcSndMvwKvXUYlgZAf/UlnPnG4yQwTfdPFOFqtzAgBYEyDN8mxfd6SEgIDE+P+pzuXIwDkAhoHU56do8lwt1E3VBOqeAADWBCgDYSXfvBLAyyfXJ30O6v/7f/vXE58vYCIwgPH5/WYQu7E2kI2k+wmELS0xb9mJpu0nwJoA1YLaI8Dtt34mfJZwGEOMm3xaAbOVgu6nbLUS1AReffXVmS1b3cKOuY8H/Vw3rAlo5FfiOHDgAC677LKZxx05cmTmvqoosiPUGgVX1y/Z0Y91Lvd3XS0tHcaRMrRGwNpAeklqArt37071mu55QE0YKcSagEZJN5VX973nPe/BY489lvt1V0k7w6GbcfOuIQSGthPabj2wJEcLpaBrdFBQLUCpe+B3Y02gRLyl/8cee6xSNYI82Y4MHXWUdGSQ1zCkpgGM5w84joQ1cgIfyxpBci1DBN6C3H///aHnnJcAvMND676nAGsCFbO6Gr7kcVH6bTET7HSODAorfW/fdwBvfvfBTF6n0zIwHDmhk8UMQ0xGEgVNXGONIJkkn58777xzZntWb+AP2r7V3Qyk1L1WwCRQcocPH576eXl5uaAria+oSszStTfM3JcmIbUMgbMbI2zrzf+6hE1cYyKIL+kQ0bDOXTYDTat3PadAfjsgqT4Ad6nklltuwfXXXx/YN5C2kytPZQlwf3L3zXjh2Bose+sLnSYhGYaYJIC1zVGqa2PTUDxGyE3r6zZoi0nWBDQJKm1473/00UcDH1O1oWl+Aa6Ixdi+8fxx3P2eK0NHDiXV79R7zHjZFLGAnJonYJombNtmEiCKIqiEm/d32N0fkOXIIcUQAtbISXVuNgtFV4ZVROs+OKPeKY4a5V//0d/izx75D9pfxzTFpAM4Cr+HslkomiLWDrJte/J/wzAmP9cVkwClljSg+QVH731RY+2hF97AV776vZm9CtY37VgBOwpDiHGNwPZvbnImzXnjn2tekNTK3bfmvenQpNVDFSYBis0d9P2GhYb97OYXnL3f7Xnf9ddPb+B/f/8VXHfZW3D0D/75zPGFrglDCKxtjuDMWe8nrrZp+P4OqgmDwT89U4jAmw4q6DelUxhgEqCEBpb0rQGo72aUTtksVogcbNq45Sfnj6Dqtc3QReGSmreYXMX69ktH1br8bjo5joN+f7zsSN0TATuGSYv2uZm0gJ6ONTUjOOqkMHfCUWv+tM9tWyUlIHEuWktMLSEdZXRTWDILei47hqPJO/wahgEhBGzbxtraWs6vXgwmAdLGMMbt5kJubSvpOBJnN0cwhIg0+SrIZ//nXZFqAL7XJQQM1+JwQrj2BxCYGv3DJp1i5T06SC0e504GdVfveg4VTpW2HSnHm74IgeV+G9t6LTiOTNRp+y++9L3ECSDMmcF4Ili7ZWDTcgI7fik/SfcTSEPtJqZGB7E5iCgCtasXgKlSv2GI6ZK2i2GMh1qG7eLl9dChH2d1yTPcNZNu27/Tl/KV9x7D3jWDODqIyCNoOKjazcv9nfUGdimBTcuZ1AocKTEcORhYNo6tbkZ6/YuXevjCR65NfP1hBsPpqr8hBDt2CyZC/tOhKfsKu7EmQJGlneAkxLiE7dZrj5dhWOy2YDsSArPJQ7FGDn7+71+Y6hrCtM9NAnO3Q7NPoFh51wSaiDUBKg3TEPijZ18NPL6pYS0gt3bLiFTyZ+0gP0X0CTQNkwBFktcyB7f85G4MRw7ObIzgyOmNYy65/k4A+oKwlFtNQGGvwQCUn6LmCTQJm4OodDotY7xjl2v5hW+/cHIyJyDs++9tzklCiK3JbjoWoaPo2BykHz/hGkkpcejQoaIvIzE1K7ioxc5UMH/k6Zfxzst3zHn09HOScDcztFsGE0AJsDlIP9YENFGbxFx33XWJN5qftxeqDmVa3fKHR87gR2+cwW3X7pk5lkWJn8qPNQH9mAQ0SRK8vUE/r0RQpsDv9sKpNfziP3xr0ZdBBdI1FJS2sL6rWZIgvmvXrtDzZb0WT78tclvLJupbcf19T+AXrpoeDup+LsfwN0MR+wk0DWsCGiUtxR89enTy7+9///tTx9zNSVUU5bKvv+8J3/sl5FTJUIj8tq9USdKv1hSUQMNqWNxdLBo2+enHJKCJCtLq/1JKSCnx4Q9/GPfcc09gP8C8+4rk3SRlsj7/uWUh5n1fHUe63pfpY2pY6PHVTRz8xM/6Pv/gcyfwM2/bOXXf5Fo8y1ZktaGLN1DHCdxhiYOiYQ7Qj0lAk6Dg/ZWvfMX3cd6+gLBzZC1qkPJ+If2WhZhcO8ZBv3VuAbmzGyMs9ccfNzX+/23/5mt4/N/fPFlQbmWhjW7IiJyLl/uBJX9viTHr4E/FYJ+AfqJMJU0fpb64IiVpDnIH+yJLqasDC1IC5y20p+4fjhx05gzLHC84B7RMfcFBRwIIep+blGzixhohBA49fyrw+HWXr5SqppyzzD447BhuKN3j/199Y4C1zRF+79svTu47enq8SNxyvz2TAFYHFs5sjOaedzxbNNtrddMVlN3nVR3xTUoASeW9x3ATsTmIInEcOWn7B7b2B3YvEy3EeJXQtc0Reh0TvbaJj1x7CTYtB0Pbwa7zuoHnPzMY4eK39P1f+1x7v/reG4bA2Y0RFromBMb9JlGXog6jOyj324L9AzEx1uvHJNBwfm3sKuhKbE3I8gZZ9yQetfmKgEC3baDb7kyOLXbHHzHv6qFeFywHJwi/ESIL3fHqo+PZo+cSkyPhSL1NRWmx9B9P0iTgHpAR51gTMQk0xDOHz/jer75k7tE0qtQdpVNu03IgBALb8qNuGBN3iQZDiJlNXwxDQPB7XStJOoYfeOCBmZn5bmoSJo2xY7ii0nyI0zZJbFg2XnljgCt2bUt1HiVsrH/QMSnHNRa/Td7VR9qy53c0u7GUrleSjuGnX1oNPP6OvcuBJf2wJBB2f4WwY5iSSxPshiMHvbYZKQEMI67/f/DvjgceC8t17gQwmbOArQXG4iQAKikRcqNMsDmIIhsMbd+Sd5AoQXjTcvD2Xcuxr2XenAVFSkz6NvKaXUzZSTJj+PDhwxqupL6YBBooSnOQ7UgIsbVGz2BoTzpjw7iDbhSW7YR2CqflHb1E1ZLkT7Z79+6Zzl9vE5H3viZjEmiYKAnAsh20za1SvIRErzO/VK9GFUVNAKsDC8v99vwH+mCpvhmS9n35dQYHHWs6JgGaUKV4dwKwRg5MM1pgj1t177fn1yyCZJ0A2ClcTlwtVD8mgQaZVwvwrtIJjNva5wX3pBu8cOcumotJQDsmgYaI2g/Q9ky0itIRHDcBWCMHGyMvWlYrAAAFw0lEQVQHS71iP34s/Zcfl5LWj0mA4EiJwdCezO7VacOy0WubudUCgvoOmACqgX8l/ZgECIYQWOjo/yicWrNgGEAvpC/ALzh7Vz+NOtnNO1uZgb96OLNXPzbKamTb9tSH+Kmnnpr827vpjFvYMV2CXsq7NENSm5aDlcV26GigoCDtXXUzajBnAqg+NfHP70bZYBLQyDSnS7z79u0Lfbw36Esp0el0Ah6djyw29RgMbQyG9sz9afILg3ozMAnox+agkrMsa+rnrGsH88bbZ/Fy/Y6Jfid8OGiSoB6laYjJotq4s5h+TAIld80110z9XLWN5gdDOzABZJJgfBIBA399cJ6AfkwCOXLPVLzqqqumjj3//PO5bjQftgpnltwTz4KkDdoM+jXGP612XEq6ouLWBOIsH53FkgwjW05mH3v3M2bQbqYkS0m/dHIj8PjeHb0mLwHBpaQpubARP46UmTTTDIb2VAIgSsIQwTfKBpuDGsZ2gpd4SLr8g3ouJGDZEiPHwVK/NZMAmBAoPn5mdGMSaJiw4XVxR2KojVwm+/oKoC2ArphNAERJsMSvH5NAA7j7A8JK+kGH1FIPXmoylrtNkWu9UJb4cdKPSYDmClvmgUinqgyFrjJ2DFMmBkM7syUmiBRuMawfawI19/Chl2I9fmRLnN0YYWUx2o5fajipe0IY+wMoK2xe1I/zBCoqajU5zvyAuIL2E2YSID9J5gkcO2MFHr9gqc15AhlgTaDmvAE5i6Rg2Q4EBFqm4NoupBVHB+nHJECxRVkKgigLbA7Sj0mgYdw1A51NRURUDUwCDRbUdp8mObA/gLLEmoB+rNdTZAzwlDduKqMfawI0IyzYq/X7uTIo5YHBXj/WBCg2d8Bn8CedRMh/lA3WBEpIbSajc1MZoipIOkRUzaPx+/6459jw+8UkUGpVSQSsDZAuSdYOWlpamtqG1fv9qdoWrbqxOahihBD88FJjLHRE4A3w/z6cPXs28HzPPPPM5N9lL1zlhctGlJC79BJUE6hCDaFqVldXsby8XPRlzFWVv31R1xnl+1MD3F6yCWr8ASbSZt535sSJEwDYHKSwJkBEtePtGHYXqC666CK8/vrrVS9gZZbBmASIiKqHzUFERJQek0BFlWWUkLoO97VcccUVEEJM2l7dj/N7bp7mXYNt2xBCYGlpKfAxeVyj9zWjvn95Xqt6rQ996EOlvk4Kx+agCip7h3HYZDe/Y3n9PmHtxN7rM00Ttm37Hsub33sVdu1FXd+86+QkyEyxOYjGylKa8puFWbZJOWGBx5sgVALw1nB0c9cC1tfXIz8HyH/cexZ/17J8NpqMM4Yptauvvrr0JbssSp979uzJ6GrCVWWMe5mvjaJjTaDiRqNRoa/vOA6effbZqfu++c1vAiiuhBpEXY9f6dNbazl9+vTU/QDw+OOP675EXHjhhbGf8/73vx9AvqXqrF7r2LFjmZyHkmNNoIJUu6r6d5FM05z8W13LTTfdNPM4db2WZU0em+fv4Fe6DroGv74DADh48KD263zttdcmr/foo48GXmfUa9fF/fp+94VdZ5k+v8SOYSKiKmLHMBERpcckQETUYEwCREQNxiRAdA7HrFMTMQlQY8wL8rfffnsm5yGqEg4RpcYIG5q4f/9+fPGLXwQwO/uZwxmpzjhElBolyk5tDdmZiqqNQ0SJ4tq9e7fvJKe4nnzyyYyuiKh4rAlQY0Qt4c97HGsHVAKsCRDF5Q7cQU1CUR5HVCesCRARVQ9rAkRElB6TABFRgzEJEBE1GJMAEVGDlX3GMOfnExFpxJoAEVGDMQkQETUYkwARUYMxCRARNRiTABFRgzEJEBE1GJMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRgzEJEBE1GJMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRgzEJEBE1GJMAEVGDMQkQETUYkwARUYMxCRARNRiTABFRg/1/QyiRhk8uSB4AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Figure size 7200x7200 with 0 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "img=mgimg.imread(fname='Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_4.0hr_map.png')\n",
-    "imgplot=plt.imshow(img)\n",
-    "plt.axis('off')\n",
-    "plt.figure(figsize=(100,100))"
+    "img = mgimg.imread(fname='Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_4.0hr_map.png')\n",
+    "fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "ax.imshow(img)\n",
+    "_ = plt.axis('off')"
    ]
   },
   {
@@ -990,13 +803,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "modeldata=pd.DataFrame()\n",
-    "modeldata['Timestep']=hydrograph_time\n",
-    "modeldata['outlet']=discharge_at_outlet\n",
-    "modeldata['midstream']=discharge_midstream\n",
-    "modeldata['upstream']=discharge_upstream\n",
-    "header={'Timestep','Outlet_cms','Midstream_cms','Upstream_cms'}\n",
-    "modeldata.to_csv(str(basin_flag + '_' + storm_flag + '_' + routing_method  + '_flow.csv'),index=False,header=header,sep=',')"
+    "modeldata = pd.DataFrame()\n",
+    "modeldata['Timestep'] = hydrograph_time\n",
+    "modeldata['outlet'] = discharge_at_outlet\n",
+    "modeldata['midstream'] = discharge_midstream\n",
+    "modeldata['upstream'] = discharge_upstream\n",
+    "header = {'Timestep', 'Outlet_cms', 'Midstream_cms', 'Upstream_cms'}\n",
+    "modeldata.to_csv(str(basin_flag + '_' + storm_flag + '_' + routing_method  + '_flow.csv'), index=False, header=header, sep=',')"
    ]
   },
   {
@@ -1005,8 +818,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('The model your have just run will have individual snapshots of the aninimation with this file naming structure --')\n",
-    "#change this shell script below list all file names for a png based on your model (e.g. *png, Spring*png, or Square*png)\n",
+    "print('The code you ran above produced image files of model output.')\n",
+    "print('The files have a naming structure that includes the model time. The files:')\n",
+    "\n",
+    "# Change the shell script below to list all the file names for a png based on your model (e.g., *png, Spring*png, or Square*png).\n",
     "!ls *csv\n",
     "\n",
     "\n",
@@ -1019,7 +834,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "** You completed the tutorial to run the model. You can now explore different routing methods and model parameters  by editing and re-executing sections by making model decisions (4.0), running the model (5.0) and saving results (6.0). Repeat as many model runs as you like and save all of your results before you start comparing results.**  \n",
+    "**You completed the tutorial to run the model. You can now explore different routing methods and model parameters  by editing and re-executing sections by making model decisions (4.0), running the model (5.0) and saving results (6.0). Repeat as many model runs as you like and save all of your results before you start comparing results.**  \n",
     "\n"
    ]
   },
@@ -1029,8 +844,7 @@
    "source": [
     "## 7.0. Discussion \n",
     "\n",
-    "In this section you will visualize results from your model runs to compare results obtained in the two study watersheds and begin writing your observations from model runs. In this section you may also generate more research questions to explore with the two models. You will also see how two methods can yield different results. \n",
-    "\n"
+    "In this section you will visualize results from your model runs to compare results obtained in the two study watersheds and begin writing your observations from model runs. In this section you may also generate more research questions to explore with the two models. You will also see how the two methods can yield different results."
    ]
   },
   {
@@ -1039,7 +853,9 @@
    "source": [
     "### 7.1. Plot maps of water depth for two model runs  \n",
     "\n",
-    "Choose two image files printed in each animation increment **from two different models** to compare at a timestep that is most interesting. \n"
+    "Choose two image files printed in each animation increment **from two different models** to compare at a timestep that is most interesting. \n",
+    "\n",
+    "**Note:** You will get the error `No such file or directory` following the code block below if you have not run the `OverlandFlow` option of the `routing_method`. In summary, you must the routing method, rerun the model, then the code block below can be run successfully."
    ]
   },
   {
@@ -1048,21 +864,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hydrograph_fig = plt.figure(figsize=(20, 18) )\n",
+    "hydrograph_fig = plt.figure(figsize=(20, 18))\n",
     "ax1 = hydrograph_fig.add_subplot(221)\n",
-    "fname1='Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_2.66666666667hr_map.png'\n",
-    "img1=mgimg.imread(fname1)\n",
-    "imgplot=plt.imshow(img1)\n",
+    "fname1 = 'Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_2.66666666667hr_map.png'\n",
+    "img1 = mgimg.imread(fname1)\n",
+    "imgplot = plt.imshow(img1)\n",
     "ax1.axis('off')\n",
     "\n",
-    "## Plotting the hydrographs from the Spring Creek DEM at the outlet\n",
+    "# Plotting the hydrographs from the Spring Creek DEM at the outlet\n",
     "ax2 = hydrograph_fig.add_subplot(222)\n",
-    "fname2='Spring Creek_HigherIntensity_OverlandFlow_2.66666666667hr_map.png'\n",
-    "img2=mgimg.imread(fname2)\n",
-    "imgplot=plt.imshow(img2)\n",
-    "ax2.axis('off')\n",
-    "\n",
-    "# KRB note, I got an error IOError: [Errno 2] No such file or directory: 'Spring Creek_HigherIntensity_OverlandFlow_2.66666666667hr_map.png'\n"
+    "fname2 = 'Spring Creek_HigherIntensity_OverlandFlow_2.66666666667hr_map.png'\n",
+    "img2 = mgimg.imread(fname2)\n",
+    "imgplot = plt.imshow(img2)\n",
+    "ax2.axis('off')"
    ]
   },
   {
@@ -1078,8 +892,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls -lt *_hydrograph.png\n",
-    "\n"
+    "!ls -lt *_hydrograph.png"
    ]
   },
   {
@@ -1088,18 +901,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hydrograph_fig = plt.figure(figsize=(20 , 20) )\n",
+    "hydrograph_fig = plt.figure(figsize=(20, 20))\n",
     "ax1 = hydrograph_fig.add_subplot(221)\n",
-    "fname1='Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_hydrograph.png'\n",
-    "img1=mgimg.imread(fname1)\n",
-    "imgplot=plt.imshow(img1)\n",
+    "fname1 = 'Spring Creek_HigherIntensity_KinwaveImplicitOverlandFlow_hydrograph.png'\n",
+    "img1 = mgimg.imread(fname1)\n",
+    "imgplot = plt.imshow(img1)\n",
     "ax1.axis('off')\n",
     "\n",
-    "## Plotting the hydrographs from the Spring Creek DEM at the outlet\n",
+    "# Plot the hydrographs from the Spring Creek DEM at the outlet.\n",
     "ax2 = hydrograph_fig.add_subplot(222)\n",
-    "fname2='Spring Creek_HigherIntensity_OverlandFlow_hydrograph.png'\n",
-    "img2=mgimg.imread(fname2)\n",
-    "imgplot=plt.imshow(img2)\n",
+    "fname2 = 'Spring Creek_HigherIntensity_OverlandFlow_hydrograph.png'\n",
+    "img2 = mgimg.imread(fname2)\n",
+    "imgplot = plt.imshow(img2)\n",
     "ax2.axis('off')"
    ]
   },
@@ -1107,40 +920,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8.0. Conclusions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you have reached this point, you should have produced a plot of three hydrographs from different points on the Spring Creek watershed, produced from overland flow driven by the base storm.\n",
+    "## 8.0. Conclusions\n",
     "\n",
-    "There are six scenarios to explore: two different watersheds and three different storms, if you use the default parameters. If you explore different Manning's roughness values run all six scenarios by systematically changing the *basin_flag* and *storm_flag* in Code Block 2 and rerunning all of the code blocks sequentially. Save the hydrograph plots for each scenario. \n",
+    "At this point in the notebook, you should have produced a plot of three hydrographs from different points in the Spring Creek watershed, produced from overland flow driven by the base storm.\n",
     "\n",
-    "**Directions if you are using this as a laboratory exercise**\n",
+    "There are six scenarios to explore: two different watersheds and three different storms, if you use the default parameters. If you explore different Manning's roughness values run all six scenarios by systematically changing the `basin_flag` and `storm_flag` in Code Block 2 and rerunning all of the code blocks sequentially. Save the hydrograph plots for each scenario. \n",
     "\n",
-    "Include those plots in a document that also contains your typed answers to each of the questions below. Answer all of the questions with complete sentences. Try to be as specific and as quantitative as you can. (e.g. You can compare times to peak discharge and peak discharge values among the scenarios.) You are encouraged to discuss the results of the models with your classmates, but the text you turn in must be your own thoughts and words.\n",
+    "### Directions if you are using this as a laboratory exercise\n",
+    "\n",
+    "Include those plots in a document that also contains your typed answers to each of the questions below. Answer all of the questions with complete sentences. Try to be as specific and as quantitative as you can. For example, you can compare times to peak discharge and peak discharge values among the scenarios. You are encouraged to discuss the results of the models with your classmates, but the text you turn in must be your own thoughts and words.\n",
     "\n",
     "1. What aspects of the hydrograph change at the outlet as the storm gets longer or more intense? Are there aspects of the outlet hydrograph that are not sensitive to the storm duration or intensity? Do the midstream and upstream hydrographs exhibit the same sensitivity to storm duration and intensity? Explain why.  \n",
     "\n",
-    "2. What are the differences in the hydrograph responce in the outlets of the two watersheds? How does the watershed shape influence the hydrograph shape?\n",
+    "2. What are the differences in the hydrograph response in the outlets of the two watersheds? How does the watershed shape influence the hydrograph shape?\n",
     "\n",
-    "3. Now compare the hydrograph shapes across the three different locations in the watersheds. Compare only between similar points (e.g. mid or upstream locations) and between the same storm characteristics. How does watershed shape affect hydrograph shape? Does it impact all locations in the same manner? Do different storm charactersitics exaggerate the differences between the different watersheds?\n",
+    "3. Now compare the hydrograph shapes across the three different locations in the watersheds. Compare only between similar points (e.g. mid or upstream locations) and between the same storm characteristics. How does watershed shape affect hydrograph shape? Does it impact all locations in the same manner? Do different storm characteristics exaggerate the differences between the different watersheds?\n",
     "\n",
     "4. Now compare the results between the two different watershed. How different are hydrograph characteristics between the square and natural watershed (Spring Creek)?\n",
     "\n",
-    "5. Please compare your answers to the questions you answered before running the models. Do the model results match your intuition? If not, do you think your intuition was wrong, or the model was wrong, or both? Remember, models are helpful for learning but they are highly simplified representations of the real world. Wihtout knowing the details of the model, does it seem like something is missing from your model results?"
+    "5. Please compare your answers to the questions you answered before running the models. Do the model results match your intuition? If not, do you think your intuition was wrong, or the model was wrong, or both? Remember, models are helpful for learning but they are highly simplified representations of the real world. Without knowing the details of the model, does it seem like something is missing from your model results?"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9.0. Save the results back into HydroShare\n",
+    "## 9.0. Save the results in HydroShare\n",
     "<a name=\"creation\"></a>\n",
     "\n",
-    "Using the `hs_utils` library, the results of the Geoprocessing steps above can be saved back into HydroShare.  First, define all of the required metadata for resource creation, i.e. *title*, *abstract*, *keywords*, *content files*.  In addition, we must define the type of resource that will be created, in this case *genericresource*."
+    "Using the HydroShare utilities library, the results of the Geoprocessing steps above can be saved in HydroShare.  First, define all of the required metadata for resource creation, i.e. *title*, *abstract*, *keywords*, *content files*.  In addition, we must define the type of resource that will be created, in this case *genericresource*."
    ]
   },
   {
@@ -1148,7 +956,7 @@
    "metadata": {},
    "source": [
     "### 9.1. List files to export to new HydroShare resource\n",
-    "The name of files listed below need to be consistent with what exist in your file directory"
+    "The name of files listed below need to be consistent with what exists in your file directory"
    ]
   },
   {
@@ -1157,22 +965,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ThisNotebook='explore_routing_tutorial.ipynb' #check name for consistency\n",
-    "modelresults='Square_HigherIntensity_OverlandFlow_flow.csv'\n",
-    "animation='animation.mp4'\n",
-    "hydrograph='Square_HigherIntensity_OverlandFlow_3.0hr_map.png'\n",
+    "ThisNotebook = 'explore_routing_tutorial.ipynb' # check name for consistency\n",
+    "modelresults = 'Square_HigherIntensity_OverlandFlow_flow.csv'\n",
+    "animation = 'animation.mp4'\n",
+    "hydrograph ='Square_HigherIntensity_OverlandFlow_3.0hr_map.png'\n",
     "\n",
-    "files=[ThisNotebook,\n",
-    "       modelresults,\n",
-    "       animation,\n",
-    "       hydrograph]"
+    "files = [ThisNotebook, modelresults, animation, hydrograph]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 9.2. Generate a new HydroShare resource with Title, Abstract, Keyword and files (listed above). \n",
+    "### 9.2. Generate a new HydroShare resource with Title, Abstract, Keyword and files (listed above)\n",
+    "\n",
     "The metadata can be edited from HydroShare once the new resource is created.  "
    ]
   },
@@ -1182,13 +988,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for each file downloaded onto the server folder, move to a new HydroShare Generic Resource\n",
+    "# For each file downloaded onto the server folder, move to a new HydroShare Generic Resource.\n",
     "title = 'Test Delete'\n",
     "abstract = 'abstract text '\n",
     "keywords = ['Landlab', 'routing'] \n",
     "rtype = 'genericresource'  \n",
     "\n",
-    "#create the new resource\n",
+    "# Create the new resource.\n",
     "resource_id = hs.createHydroShareResource(abstract, \n",
     "                                          title,\n",
     "                                          keywords=keywords, \n",
@@ -1201,8 +1007,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 10.0 Clean up - be a good community data steward - Thank You!\n",
-    "After checking that all of the files you want are saved on HydroShare, use shell scripting from the Notebook to view and delete data.  \n"
+    "## 10.0 Clean up—be a good community data steward—thank you!\n",
+    "Check that all of the files you want are saved on HydroShare. Then use shell scripting from the Notebook to view and delete data.  \n"
    ]
   },
   {
@@ -1211,9 +1017,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Print current working directory and make sure you are in the correct directory you want to clean up\n",
+    "# Print current working directory and make sure you are in the directory you want to clean up.\n",
     "!pwd\n",
-    "#List files in directory with date of creation. Check that you don’t need any of these files. \n",
+    "\n",
+    "# List files in directory with date of creation. Check that you do not need any of these files. \n",
     "!ls -lt "
    ]
   },
@@ -1223,11 +1030,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Remove all files you created. This will not remove the Notebook you are using now.   \n",
+    "# Remove all files you created. This will not remove the Notebook you are using now.   \n",
     "!rm *png\n",
     "!rm *mp4\n",
     "!rm *csv\n",
-    "#List everything remaining in the folder - this should be only what you downloaded from HydroShare. Note that all of this will be overwritten the next time you Open With from the HydroShare webpage for this resource, execute the Welcome page, and answer ‘Yes’ to download the data again from HydroShare.  \n",
+    "\n",
+    "# List everything remaining in the folder - this should be only what you downloaded from\n",
+    "# HydroShare. Note that all of this will be overwritten the next time you `Open With`\n",
+    "# from the HydroShare webpage for this resource, execute the Welcome page, and answer\n",
+    "# ‘Yes’ to download the data again from HydroShare.  \n",
     "!ls -lt"
    ]
   }
@@ -1235,21 +1046,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2.7",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Upper sections

I removed the first paragraph because I thought it would be confusing to have this broader topic under the notebook header. Vital parts of what was in the first paragraph could instead be included in the `Data Science and Cyberinfrastructure` section I proposed.

How about using the `Objectives` and `About this notebook` sections in each of the 3 notebooks? The notebooks are all almost set up this way. I suppose I am suggesting to make them a little more consistent...only in these sections.

## Summary of changes

markdown cells in general
* changed headings that were bolded to true markdown headings using `#`
* corrected the few spelling errors
* minor wordsmithing for content clarity
<hr>

code cells in general
* coding style modified to more closely follow [PEP 8](https://www.python.org/dev/peps/pep-0008) (mostly spacing)
* added legends to imshow figs of the sampled points (e.g. midstream node)
<hr>

In section 2.3 and 9.0, `hs_utils` is mentioned in a markdown cell, but is not clear in a code cell. I believe this refers to the lines in 2.3:

```python
from utilities import hydroshare

hs = hydroshare.hydroshare()
```

For this reason, I changed `hs_utils` to `hydroshare`. Please check if this is appropriate.
<hr>

In 2.3, 'This is the list of folders in your directory for this HydroShare resource' is followed by `os.getcwd()`. This is only the current directory. You could do `next(os.walk('.'))[1]`. Alternatively, you could remove these print statements if it doesn't add much insight.
<hr>
Added a warning about processing time for the overland flow model cell.
<hr>

Suppressed figure handle output, e.g. `<Figure...>` as well as the additional imshow output immediately after the animation by closing the imshow_grid figure.
<hr>

Added note about needing to rerun model with different `OverlandFlow` option of the `routing_method` in response to:

```
KRB note, I got an error IOError: [Errno 2] No such file or directory: 'Spring Creek_HigherIntensity_OverlandFlow_2.66666666667hr_map.png
```
<hr>

Removed text that indicated saving images and the animation are related. The animation does not rely on the `savefig` command or `image_save` variable. The animation module grabs the figure at time steps created by `imshow_grid`.

## Manual testing

I did this in a Safari browser in a python 3 HydroShare kernel.

* My modified code blocks ran and printed the same output (of the output that was in the current notebook) with exception of the modified figures I explained elsewhere.
* All the links open the intended webpages.
* The animation works.

## Remaining to do

* update mentions of sections
* 'KRB note: How do I download this file?' in section 6.3. I think the intent of this cell is only to list the files.